### PR TITLE
Hotfix: Check Overflow on Named Semaphores Table

### DIFF
--- a/src/servers/semaphore-server.c
+++ b/src/servers/semaphore-server.c
@@ -385,7 +385,8 @@ static int semaphore_create(int owner, char *name, mode_t mode, int value)
 	}
 
 	/* Allocate a new semaphore. */
-	semid = semaphore_alloc();
+	if ((semid = semaphore_alloc()) < 0)
+		return (-ENOENT);
 
 	/* Initialize semaphore. */
 	semaphores[semid].count = value;


### PR DESCRIPTION
In this commit I check the allocation of a semaphore, returning an
error if overflow occurs.

Files modified:

	- src/servers/semaphore-server.c

This commit fixes #96