### PR TITLE
Bug fix: Correct check at opening of a shm

### DIFF
--- a/src/servers/shm/shm.c
+++ b/src/servers/shm/shm.c
@@ -21,6 +21,7 @@
  */
 
 #include <sys/types.h>
+#include <sys/stat.h>
 #include <stdint.h>
 #include <string.h>
 
@@ -123,19 +124,39 @@ int shm_is_owner(int shmid, int node)
 }
 
 /*============================================================================*
- * shm_get_owner()                                                                  *
+ * shm_is_readable()                                                          *
  *============================================================================*/
 
 /**
- * @brief Gets a shared memory region owner.
+ * @brief Asserts whether or not a given shared memory region has
+ * read permission.
  *
  * @param shmid Target shared memory region.
  *
- * @return ID of the shared memory region's owner.
+ * @returns Non-zero if the target shared memory region is readable,
+ * and zero otherwise.
  */
-int shm_get_owner(int shmid)
+int shm_is_readable(int shmid)
 {
-	return regions[shmid].owner;
+	return (regions[shmid].mode & S_IRUSR);
+}
+
+/*============================================================================*
+ * shm_is_writable()                                                          *
+ *============================================================================*/
+
+/**
+ * @brief Asserts whether or not a given shared memory region has
+ * write permission.
+ *
+ * @param shmid Target shared memory region.
+ *
+ * @returns Non-zero if the target shared memory region is writable,
+ * and zero otherwise.
+ */
+int shm_is_writable(int shmid)
+{
+	return (regions[shmid].mode & S_IWUSR);
 }
 
 /*============================================================================*

--- a/src/servers/shm/shm.h
+++ b/src/servers/shm/shm.h
@@ -41,7 +41,8 @@
 	extern int shm_is_used(int);
 	extern int shm_is_remove(int);
 	extern int shm_is_owner(int, int);
-	extern int shm_get_owner(int);
+	extern int shm_is_readable(int);
+	extern int shm_is_writable(int);
 	extern uint64_t shm_get_base(int);
 	extern size_t shm_get_size(int);
 	extern void shm_set_remove(int);

--- a/src/ubin/test/master/posix/semaphore/api.c
+++ b/src/ubin/test/master/posix/semaphore/api.c
@@ -79,7 +79,7 @@ static void test_posix_semaphore_create_unlink(void)
 
 	/* Create and unlink semaphore. */
 	sprintf(semaphore_name, "/semaphore");
-	TEST_ASSERT((sem = sem_open(semaphore_name, O_CREAT, 0, 0)) != SEM_FAILED);
+	TEST_ASSERT((sem = sem_open(semaphore_name, O_CREAT, (S_IRUSR | S_IWUSR), 0)) != SEM_FAILED);
 	TEST_ASSERT(sem_unlink(semaphore_name) == 0);
 }
 
@@ -96,7 +96,7 @@ static void test_posix_semaphore_open_close(void)
 	char semaphore_name[NANVIX_SEM_NAME_MAX];
 
 	sprintf(semaphore_name, "/semaphore");
-	TEST_ASSERT((sem = sem_open(semaphore_name, O_CREAT, 0, 0)) != SEM_FAILED);
+	TEST_ASSERT((sem = sem_open(semaphore_name, O_CREAT, (S_IRUSR | S_IWUSR), 0)) != SEM_FAILED);
 	TEST_ASSERT((sem = sem_open(semaphore_name, 0)) != SEM_FAILED);
 	TEST_ASSERT(sem_close(sem) == 0);
 	TEST_ASSERT(sem_unlink(semaphore_name) == 0);
@@ -239,7 +239,7 @@ static void test_posix_semaphore_open_close2_cc(void)
 
 	/* Create semaphore. */
 	sprintf(semaphore_name, "/semaphore");
-	TEST_ASSERT((sem = sem_open(semaphore_name, O_CREAT, 0, 0)) != SEM_FAILED);
+	TEST_ASSERT((sem = sem_open(semaphore_name, O_CREAT, (S_IRUSR | S_IWUSR), 0)) != SEM_FAILED);
 
 	/* Create barrier. */
 	TEST_ASSERT((barrier = barrier_create(nodes, NANVIX_PROC_MAX + 1)) >= 0);
@@ -459,7 +459,7 @@ static void test_posix_semaphore_wait_post2_cc(void)
 
 	/* Create semaphore. */
 	sprintf(semaphore_name, "/semaphore");
-	TEST_ASSERT((sem = sem_open(semaphore_name, O_CREAT, 0, 1)) != SEM_FAILED);
+	TEST_ASSERT((sem = sem_open(semaphore_name, O_CREAT, (S_IRUSR | S_IWUSR), 1)) != SEM_FAILED);
 
 	/* Create barrier. */
 	TEST_ASSERT((barrier = barrier_create(nodes, NANVIX_PROC_MAX + 1)) >= 0);

--- a/src/ubin/test/master/posix/shm/api.c
+++ b/src/ubin/test/master/posix/shm/api.c
@@ -102,8 +102,8 @@ static void test_posix_shm_create_unlink4(void)
 
 	/* Create and unlink shm. */
 	sprintf(shm_name, "/shm");
-	TEST_ASSERT((shm1 = shm_open(shm_name, (O_CREAT | O_EXCL), 0)) >= 0);
-	TEST_ASSERT((shm2 = shm_open(shm_name, O_CREAT, 0)) >= 0);
+	TEST_ASSERT((shm1 = shm_open(shm_name, (O_CREAT | O_EXCL), S_IRUSR)) >= 0);
+	TEST_ASSERT((shm2 = shm_open(shm_name, O_CREAT, S_IRUSR)) >= 0);
 	TEST_ASSERT(shm_unlink(shm_name) == 0);
 	TEST_ASSERT(shm_unlink(shm_name) == 0);
 }
@@ -122,8 +122,8 @@ static void test_posix_shm_open_close1(void)
 
 	/* Create and unlink shm. */
 	sprintf(shm_name, "/shm");
-	TEST_ASSERT((shm1 = shm_open(shm_name, O_CREAT, 0)) >= 0);
-	TEST_ASSERT((shm2 = shm_open(shm_name, 0, 0)) >= 0);
+	TEST_ASSERT((shm1 = shm_open(shm_name, O_CREAT, S_IRUSR)) >= 0);
+	TEST_ASSERT((shm2 = shm_open(shm_name, 0, S_IRUSR)) >= 0);
 	TEST_ASSERT(shm_unlink(shm_name) == 0);
 	TEST_ASSERT(shm_unlink(shm_name) == 0);
 }
@@ -142,8 +142,8 @@ static void test_posix_shm_open_close2(void)
 
 	/* Create and unlink shm. */
 	sprintf(shm_name, "/shm");
-	TEST_ASSERT((shm1 = shm_open(shm_name, O_CREAT | O_RDWR, 0)) >= 0);
-	TEST_ASSERT((shm2 = shm_open(shm_name, O_TRUNC | O_RDWR, 0)) >= 0);
+	TEST_ASSERT((shm1 = shm_open(shm_name, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
+	TEST_ASSERT((shm2 = shm_open(shm_name, O_TRUNC | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(shm_unlink(shm_name) == 0);
 	TEST_ASSERT(shm_unlink(shm_name) == 0);
 }
@@ -162,7 +162,7 @@ static void test_posix_shm_truncate(void)
 
 	/* Create and unlink shm. */
 	sprintf(shm_name, "/shm");
-	TEST_ASSERT((shm = shm_open(shm_name, O_CREAT | O_RDWR, 0)) >= 0);
+	TEST_ASSERT((shm = shm_open(shm_name, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, REGION_SIZE) == 0);
 	TEST_ASSERT(shm_unlink(shm_name) == 0);
 }
@@ -181,7 +181,7 @@ static void test_posix_shm_map_unmap1(void)
 	char shm_name[SHM_NAME_MAX];
 
 	sprintf(shm_name, "/shm");
-	TEST_ASSERT((shm = shm_open(shm_name, O_CREAT | O_RDWR, 0)) >= 0);
+	TEST_ASSERT((shm = shm_open(shm_name, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, REGION_SIZE) == 0);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_READ, MAP_PRIVATE, shm, 0)) != MAP_FAILED);
 	TEST_ASSERT(munmap(map, REGION_SIZE) == 0);
@@ -202,7 +202,7 @@ static void test_posix_shm_map_unmap2(void)
 	char shm_name[SHM_NAME_MAX];
 
 	sprintf(shm_name, "/shm");
-	TEST_ASSERT((shm = shm_open(shm_name, O_CREAT | O_RDWR, 0)) >= 0);
+	TEST_ASSERT((shm = shm_open(shm_name, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, REGION_SIZE) == 0);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_WRITE, MAP_PRIVATE, shm, 0)) != MAP_FAILED);
 	TEST_ASSERT(munmap(map, REGION_SIZE) == 0);
@@ -223,7 +223,7 @@ static void test_posix_shm_map_unmap3(void)
 	char shm_name[SHM_NAME_MAX];
 
 	sprintf(shm_name, "/shm");
-	TEST_ASSERT((shm = shm_open(shm_name, O_CREAT | O_RDWR, 0)) >= 0);
+	TEST_ASSERT((shm = shm_open(shm_name, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, REGION_SIZE) == 0);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_READ, MAP_SHARED, shm, 0)) != MAP_FAILED);
 	TEST_ASSERT(munmap(map, REGION_SIZE) == 0);
@@ -244,7 +244,7 @@ static void test_posix_shm_map_unmap4(void)
 	char shm_name[SHM_NAME_MAX];
 
 	sprintf(shm_name, "/shm");
-	TEST_ASSERT((shm = shm_open(shm_name, O_CREAT | O_RDWR, 0)) >= 0);
+	TEST_ASSERT((shm = shm_open(shm_name, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, REGION_SIZE) == 0);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_WRITE, MAP_SHARED, shm, 0)) != MAP_FAILED);
 	TEST_ASSERT(munmap(map, REGION_SIZE) == 0);
@@ -265,7 +265,7 @@ static void test_posix_shm_map_unmap5(void)
 	char shm_name[SHM_NAME_MAX];
 
 	sprintf(shm_name, "/shm");
-	TEST_ASSERT((shm = shm_open(shm_name, O_CREAT | O_RDWR, 0)) >= 0);
+	TEST_ASSERT((shm = shm_open(shm_name, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, 2*REGION_SIZE) == 0);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_READ, MAP_PRIVATE, shm, REGION_SIZE)) != MAP_FAILED);
 	TEST_ASSERT(munmap(map, REGION_SIZE) == 0);
@@ -286,7 +286,7 @@ static void test_posix_shm_map_unmap6(void)
 	char shm_name[SHM_NAME_MAX];
 
 	sprintf(shm_name, "/shm");
-	TEST_ASSERT((shm = shm_open(shm_name, O_CREAT | O_RDWR, 0)) >= 0);
+	TEST_ASSERT((shm = shm_open(shm_name, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, 2*REGION_SIZE) == 0);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_WRITE, MAP_PRIVATE, shm, REGION_SIZE)) != MAP_FAILED);
 	TEST_ASSERT(munmap(map, REGION_SIZE) == 0);
@@ -307,7 +307,7 @@ static void test_posix_shm_map_unmap7(void)
 	char shm_name[SHM_NAME_MAX];
 
 	sprintf(shm_name, "/shm");
-	TEST_ASSERT((shm = shm_open(shm_name, O_CREAT | O_RDWR, 0)) >= 0);
+	TEST_ASSERT((shm = shm_open(shm_name, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, 2*REGION_SIZE) == 0);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_READ, MAP_SHARED, shm, REGION_SIZE)) != MAP_FAILED);
 	TEST_ASSERT(munmap(map, REGION_SIZE) == 0);
@@ -328,7 +328,7 @@ static void test_posix_shm_map_unmap8(void)
 	char shm_name[SHM_NAME_MAX];
 
 	sprintf(shm_name, "/shm");
-	TEST_ASSERT((shm = shm_open(shm_name, O_CREAT | O_RDWR, 0)) >= 0);
+	TEST_ASSERT((shm = shm_open(shm_name, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, 2*REGION_SIZE) == 0);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_WRITE, MAP_SHARED, shm, REGION_SIZE)) != MAP_FAILED);
 	TEST_ASSERT(munmap(map, REGION_SIZE) == 0);
@@ -348,7 +348,7 @@ static void test_posix_shm_map_unmap9(void)
 	char shm_name[SHM_NAME_MAX];
 
 	sprintf(shm_name, "/shm");
-	TEST_ASSERT((shm = shm_open(shm_name, O_CREAT | O_RDWR, 0)) >= 0);
+	TEST_ASSERT((shm = shm_open(shm_name, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, REGION_SIZE) == 0);
 	TEST_ASSERT((map1 = mmap(NULL, REGION_SIZE, PROT_WRITE, MAP_SHARED, shm, 0)) != MAP_FAILED);
 	TEST_ASSERT(munmap(map1, REGION_SIZE) == 0);
@@ -371,7 +371,7 @@ static void test_posix_shm_sync1(void)
 	char shm_name[SHM_NAME_MAX];
 
 	sprintf(shm_name, "/shm");
-	TEST_ASSERT((shm = shm_open(shm_name, O_CREAT | O_RDWR, 0)) >= 0);
+	TEST_ASSERT((shm = shm_open(shm_name, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, REGION_SIZE) == 0);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_WRITE, MAP_SHARED, shm, 0)) != MAP_FAILED);
 
@@ -397,7 +397,7 @@ static void test_posix_shm_sync2(void)
 	char shm_name[SHM_NAME_MAX];
 
 	sprintf(shm_name, "/shm");
-	TEST_ASSERT((shm = shm_open(shm_name, O_CREAT | O_RDWR, 0)) >= 0);
+	TEST_ASSERT((shm = shm_open(shm_name, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, REGION_SIZE) == 0);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_WRITE, MAP_SHARED, shm, 0)) != MAP_FAILED);
 

--- a/src/ubin/test/master/posix/shm/fault.c
+++ b/src/ubin/test/master/posix/shm/fault.c
@@ -171,7 +171,7 @@ static void test_posix_shm_invalid_truncate(void)
 {
 	int shm;
 
-	TEST_ASSERT((shm = shm_open("/shm", O_CREAT | O_RDWR, 0)) >= 0);
+	TEST_ASSERT((shm = shm_open("/shm", O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(-1, REGION_SIZE) < 0);
 	TEST_ASSERT(ftruncate(1000000, REGION_SIZE) < 0);
 	TEST_ASSERT(ftruncate(shm, RMEM_SIZE + 1) < 0);
@@ -190,12 +190,12 @@ static void test_posix_shm_bad_truncate(void)
 	int shm;
 	void *map;
 
-	TEST_ASSERT((shm = shm_open("/shm", O_CREAT | O_RDONLY, 0)) >= 0);
+	TEST_ASSERT((shm = shm_open("/shm", O_CREAT | O_RDONLY, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, REGION_SIZE) < 0);
 	TEST_ASSERT(ftruncate(1, REGION_SIZE) < 0);
 	TEST_ASSERT(shm_unlink("/shm") == 0);
 
-	TEST_ASSERT((shm = shm_open("/shm", O_CREAT | O_RDWR, 0)) >= 0);
+	TEST_ASSERT((shm = shm_open("/shm", O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, REGION_SIZE) == 0);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_READ, MAP_PRIVATE, shm, 0)) != MAP_FAILED);
 	TEST_ASSERT(ftruncate(shm, 2*REGION_SIZE) < 0);
@@ -215,7 +215,7 @@ static void test_posix_shm_invalid_map(void)
 	int shm;
 	void *map;
 
-	TEST_ASSERT((shm = shm_open("/shm", O_CREAT | O_RDWR, 0)) >= 0);
+	TEST_ASSERT((shm = shm_open("/shm", O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT((map = mmap(NULL, 0, PROT_READ, MAP_PRIVATE, shm, 0)) == MAP_FAILED);
 	TEST_ASSERT(ftruncate(shm, REGION_SIZE) == 0);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_READ, MAP_PRIVATE, -1, 0)) == MAP_FAILED);
@@ -238,7 +238,7 @@ static void test_posix_shm_bad_map(void)
 	int shm;
 	void *map;
 
-	TEST_ASSERT((shm = shm_open("/shm", O_CREAT | O_RDWR, 0)) >= 0);
+	TEST_ASSERT((shm = shm_open("/shm", O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, REGION_SIZE) == 0);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_READ, MAP_PRIVATE, 1, 0)) == MAP_FAILED);
 	TEST_ASSERT(shm_unlink("/shm") == 0);
@@ -256,7 +256,7 @@ static void test_posix_shm_invalid_unmap(void)
 	int shm;
 	void *map;
 
-	TEST_ASSERT((shm = shm_open("/shm", O_CREAT | O_RDWR, 0)) >= 0);
+	TEST_ASSERT((shm = shm_open("/shm", O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, REGION_SIZE) == 0);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_READ, MAP_PRIVATE, shm, 0)) != MAP_FAILED);
 	TEST_ASSERT(munmap(NULL, REGION_SIZE) < 0);
@@ -279,7 +279,7 @@ static void test_posix_shm_bad_unmap(void)
 	int shm;
 	void *map;
 
-	TEST_ASSERT((shm = shm_open("/shm", O_CREAT | O_RDWR, 0)) >= 0);
+	TEST_ASSERT((shm = shm_open("/shm", O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, REGION_SIZE) == 0);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_READ, MAP_PRIVATE, shm, 0)) != MAP_FAILED);
 	TEST_ASSERT(munmap((void *)test_posix_shm_bad_unmap, REGION_SIZE) < 0);
@@ -300,7 +300,7 @@ static void test_posix_shm_invalid_sync(void)
 	int shm;
 	void *map;
 
-	TEST_ASSERT((shm = shm_open("/shm", O_CREAT | O_RDWR, 0)) >= 0);
+	TEST_ASSERT((shm = shm_open("/shm", O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, REGION_SIZE) == 0);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_WRITE, MAP_SHARED, shm, 0)) != MAP_FAILED);
 
@@ -328,7 +328,7 @@ static void test_posix_shm_bad_sync(void)
 	int shm;
 	void *map;
 
-	TEST_ASSERT((shm = shm_open("/shm", O_CREAT | O_RDWR, 0)) >= 0);
+	TEST_ASSERT((shm = shm_open("/shm", O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, REGION_SIZE) == 0);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_WRITE, MAP_SHARED, shm, 0)) != MAP_FAILED);
 	memset(map, 1, REGION_SIZE);
@@ -336,13 +336,41 @@ static void test_posix_shm_bad_sync(void)
 	TEST_ASSERT(munmap(map, REGION_SIZE) == 0);
 	TEST_ASSERT(shm_unlink("/shm") == 0);
 
-	TEST_ASSERT((shm = shm_open("/shm", O_CREAT | O_RDWR, 0)) >= 0);
+	TEST_ASSERT((shm = shm_open("/shm", O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, REGION_SIZE) == 0);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_READ, MAP_SHARED, shm, 0)) != MAP_FAILED);
 	memset(map, 1, REGION_SIZE);
 	TEST_ASSERT(msync(map, REGION_SIZE, MS_SYNC) < 0);
 	TEST_ASSERT(munmap(map, REGION_SIZE) == 0);
 	TEST_ASSERT(shm_unlink("/shm") == 0);
+}
+
+/*============================================================================*
+ * Fault Injection Test: Invalid OFlags                                       *
+ *============================================================================*/
+
+/**
+ * @brief Fault Injection Test: Invalid OFlags
+ */
+static void test_posix_shm_invalid_oflags(void)
+{
+	int shm;
+
+	TEST_ASSERT((shm = shm_open("cool-name", O_CREAT, 0)) >= 0);
+	TEST_ASSERT(shm_open("cool-name", O_CREAT, 0) < 0);
+	TEST_ASSERT(shm_open("cool-name", O_RDONLY, 0) < 0);
+	TEST_ASSERT(shm_open("cool-name", O_RDWR, 0) < 0);
+	TEST_ASSERT(shm_unlink("cool-name") == 0);
+
+	TEST_ASSERT((shm = shm_open("cool-name2", O_CREAT, S_IRUSR)) >= 0);
+	TEST_ASSERT(shm_open("cool-name2", O_RDWR, 0) < 0);
+	TEST_ASSERT(shm_unlink("cool-name2") == 0);
+
+	TEST_ASSERT((shm = shm_open("cool-name3", O_CREAT, S_IWUSR)) >= 0);
+	TEST_ASSERT(shm_open("cool-name3", O_CREAT, 0) < 0);
+	TEST_ASSERT(shm_open("cool-name3", O_RDONLY, 0) < 0);
+	TEST_ASSERT(shm_open("cool-name3", O_RDWR, 0) < 0);
+	TEST_ASSERT(shm_unlink("cool-name3") == 0);
 }
 
 /*============================================================================*/
@@ -367,5 +395,6 @@ struct test posix_shm_tests_fault[] = {
 	{ test_posix_shm_bad_unmap,        "Bad Ununmap"      },
 	{ test_posix_shm_invalid_sync,     "Invalid Sync"     },
 	{ test_posix_shm_bad_sync,         "Bad Sync"         },
+	{ test_posix_shm_invalid_oflags,   "Invalid OFlags"   },
 	{ NULL,                            NULL               },
 };

--- a/src/ubin/test/slave/posix/semaphore/slave.c
+++ b/src/ubin/test/slave/posix/semaphore/slave.c
@@ -61,7 +61,7 @@ static void test_posix_semaphore_create_unlink_cc(int masternode, int nclusters)
 
 	/* Create and unlink semaphore. */
 	sprintf(semaphore_name, "/semaphore%d", nodenum);
-	TEST_ASSERT((sem = sem_open(semaphore_name, O_CREAT, 0, 0)) != SEM_FAILED);
+	TEST_ASSERT((sem = sem_open(semaphore_name, O_CREAT, (S_IRUSR | S_IWUSR), 0)) != SEM_FAILED);
 	TEST_ASSERT(sem_unlink(semaphore_name) == 0);
 
 	/* Sync. */
@@ -96,7 +96,7 @@ static void test_posix_semaphore_open_close_cc(int masternode, int nclusters)
 
 	/* Create and unlink semaphore. */
 	sprintf(semaphore_name, "/semaphore%d", nodenum);
-	TEST_ASSERT((sem = sem_open(semaphore_name, O_CREAT, 0, 0)) != SEM_FAILED);
+	TEST_ASSERT((sem = sem_open(semaphore_name, O_CREAT, (S_IRUSR | S_IWUSR), 0)) != SEM_FAILED);
 	TEST_ASSERT((sem = sem_open(semaphore_name, 0)) != SEM_FAILED);
 	TEST_ASSERT(sem_close(sem) == 0);
 	TEST_ASSERT(sem_unlink(semaphore_name) == 0);
@@ -163,7 +163,7 @@ static void test_posix_semaphore_open_close3_cc(int masternode, int nclusters)
 
 	/* Create semaphore. */
 	sprintf(semaphore_name, "/semaphore%d", nodenum);
-	TEST_ASSERT((sem = sem_open(semaphore_name, O_CREAT, 0, 0)) != SEM_FAILED);
+	TEST_ASSERT((sem = sem_open(semaphore_name, O_CREAT, (S_IRUSR | S_IWUSR), 0)) != SEM_FAILED);
 
 	/* Sync. */
 	TEST_ASSERT(barrier_wait(barrier) == 0);
@@ -206,7 +206,7 @@ static void test_posix_semaphore_open_close4_cc(int masternode, int nclusters)
 
 	/* Create semaphore. */
 	sprintf(semaphore_name, "/semaphore%d", nodenum);
-	TEST_ASSERT((sem1 = sem_open(semaphore_name, O_CREAT, 0, 0)) != SEM_FAILED);
+	TEST_ASSERT((sem1 = sem_open(semaphore_name, O_CREAT, (S_IRUSR | S_IWUSR), 0)) != SEM_FAILED);
 
 	/* Sync. */
 	TEST_ASSERT(barrier_wait(barrier) == 0);
@@ -251,7 +251,7 @@ static void test_posix_semaphore_wait_post_cc(int masternode, int nclusters)
 
 	/* Create semaphore. */
 	if (nodenum == 0)
-		TEST_ASSERT((sem = sem_open("/semaphore", O_CREAT, 0, 1)) != SEM_FAILED);
+		TEST_ASSERT((sem = sem_open("/semaphore", O_CREAT, (S_IRUSR | S_IWUSR), 1)) != SEM_FAILED);
 
 	/* Sync. */
 	TEST_ASSERT(barrier_wait(barrier) == 0);
@@ -343,7 +343,7 @@ static void test_posix_semaphore_wait_post3_cc(int masternode, int nclusters)
 
 	/* Create semaphore. */
 	sprintf(semaphore_name, "/semaphore%d", nodenum);
-	TEST_ASSERT((sem = sem_open(semaphore_name, O_CREAT, 0, 1)) != SEM_FAILED);
+	TEST_ASSERT((sem = sem_open(semaphore_name, O_CREAT, (S_IRUSR | S_IWUSR), 1)) != SEM_FAILED);
 
 	/* Sync. */
 	TEST_ASSERT(barrier_wait(barrier) == 0);


### PR DESCRIPTION
In this commit, I correct the check while opening a shared memory
region based on the permissions set during its creation (mode_t).
I also release the shmid on the discovery of the error in the
opening flags, thus decrementing the reference counter that was
not being performed previously. And finally, I created a test
that checks for some errors when opening a shm with wrong flags.

Fix #117 