### PR TITLE
[ipc] Bad Nodes in Barrier

### DIFF
--- a/src/libs/nanvix/ipc/barrier.c
+++ b/src/libs/nanvix/ipc/barrier.c
@@ -208,7 +208,7 @@ found:
 		/* Check for a bad barrier leader. */
 		for (int i = 1; i < nnodes; i++)
 		{
-			if (nodenum < nodes[0])
+			if (nodenum < nodes[i])
 				goto error0;
 		}
 


### PR DESCRIPTION
# Description

In this PR, I introduce a new implementation for the nodes verification inside the barrier. This implementation will compare each node with the masternode to synchronize the barrier.

# Related Issues
* [Barrier nodes](https://github.com/nanvix/multikernel/issues/143)