### PR TITLE
[rmem] Enhanced Remote Memory Allocation

### DIFF
--- a/src/libs/nanvix/mm/rmem.c
+++ b/src/libs/nanvix/mm/rmem.c
@@ -61,8 +61,9 @@ int memalloc(void)
 
 	/* Send operation header. */
 	assert(mailbox_write(server.outbox, &msg, MAILBOX_MSG_SIZE) == 0);
+    assert(sys_mailbox_read(get_inbox(), &msg, MAILBOX_MSG_SIZE) == MAILBOX_MSG_SIZE);
 
-	return (0);
+	return msg.blknum;
 }
 
 /*============================================================================*
@@ -88,6 +89,7 @@ int memfree(uint64_t blknum)
 	/* Build operation header. */
 	msg.header.source = sys_get_node_num();
 	msg.header.opcode = RMEM_MEMFREE;
+    msg.blknum = blknum;
 
 	/* Send operation header. */
 	assert(mailbox_write(server.outbox, &msg, MAILBOX_MSG_SIZE) == 0);

--- a/src/servers/rmem-server.c
+++ b/src/servers/rmem-server.c
@@ -284,7 +284,10 @@ static int rmem_loop(void)
 
             /* Allocate RMEM. */
             case RMEM_MEMALLOC:
-                rmem_malloc();
+                blk = rmem_malloc();
+                source = sys_mailbox_open(msg.header.source);
+                mailbox_write(source, &blk, msg.size);
+                mailbox_close(source);
                 break;
 
             /* Free  RMEM. */

--- a/src/ubin/test/master/nanvix/mm/rmem/api.c
+++ b/src/ubin/test/master/nanvix/mm/rmem/api.c
@@ -92,6 +92,38 @@ static void join_slaves(void)
 }
 
 /*============================================================================*
+ * API Test: Alloc                                                            *
+ *============================================================================*/
+
+/**
+ * @brief API Test: Alloc
+ */
+static void test_mm_rmem_alloc(void)
+{
+	TEST_ASSERT(memalloc() == 0);
+    TEST_ASSERT(memalloc() == 1);
+    TEST_ASSERT(memalloc() == 2);
+    TEST_ASSERT(memalloc() == 3);
+}
+
+/*============================================================================*
+ * API Test: Free                                                             *
+ *============================================================================*/
+
+/**
+ * @brief API Test Free
+ */
+static void test_mm_rmem_free(void)
+{
+    TEST_ASSERT(memfree(1) == 0);
+    TEST_ASSERT(memalloc() == 1);
+    TEST_ASSERT(memfree(0) == 0);
+    TEST_ASSERT(memfree(2) == 0);
+    TEST_ASSERT(memalloc() == 0);
+    TEST_ASSERT(memalloc() == 2);
+}
+
+/*============================================================================*
  * API Test: Read Write                                                       *
  *============================================================================*/
 
@@ -169,5 +201,7 @@ static void test_mm_rmem_read_write_cc(void)
 struct test mm_rmem_tests_api[] = {
 	{ test_mm_rmem_read_write,    "Read Write"    },
 	{ test_mm_rmem_read_write_cc, "Read Write CC" },
+	{ test_mm_rmem_alloc,         "Alloc"         },
+	{ test_mm_rmem_free,          "Free"          },
 	{ NULL,                       NULL            },
 };


### PR DESCRIPTION
# Description
In this PR, I introduce an alloc enhancement and tests for it. More precisely, the rmem service will now provide a simple block allocation function. Moreover, this function is tested extensively with happy cases.

# Related Issues

[[rmem] Remote Memory Allocation](https://github.com/nanvix/multikernel/issues/100)
[[rmem] Block Number Information](https://github.com/nanvix/multikernel/issues/138)