### PR TITLE
[rmem] Invalid Alloc and Free Unit Tests

### DIFF
--- a/include/nanvix/mm.h
+++ b/include/nanvix/mm.h
@@ -36,7 +36,7 @@
 	/**
 	 * @brief Remote memory block size (in bytes).
 	 */
-	#define RMEM_BLOCK_SIZE (1024*1024)
+	#define RMEM_BLOCK_SIZE 1024
 
 	/**
 	 * @brief Remote memory size (in bytes).

--- a/include/nanvix/utils.h
+++ b/include/nanvix/utils.h
@@ -26,8 +26,51 @@
 	#include <errno.h>
 	#include <stdio.h>
 	#include <string.h>
+	#include <stdint.h>
+
+	/*========================================================================*
+	 *                                Bitmap                                  *
+	 *========================================================================*/
+
+	/**
+	 * @brief Bit number.
+	 */
+	typedef uint32_t bit_t;
+
+	/**
+	 * @brief Full bitmap.
+	 */
+	#define BITMAP_FULL 0xffffffff
+
+	/**
+	 * @name Bitmap Operators
+	 */
+	#define IDX(a) ((a) >> 5)   /**< Returns the index of the bit.  */
+	#define OFF(a) ((a) & 0x1F) /**< Returns the offset of the bit. */
+
+	/**
+	 * @brief Sets a bit in a bitmap.
+	 *
+	 * @param bitmap Bitmap where the bit should be set.
+	 * @param pos    Position of the bit that shall be set.
+	 */
+	#define bitmap_set(bitmap, pos) \
+		(((uint32_t *)(bitmap))[IDX(pos)] |= (0x1 << OFF(pos)))
+
+	/**
+	 * @brief Clears a bit in a bitmap.
+	 *
+	 * @param bitmap Bitmap where the bit should be cleared.
+	 * @param pos    Position of the bit that shall be cleared.
+	 */
+	#define bitmap_clear(bitmap, pos) \
+		(((uint32_t *)(bitmap))[IDX(pos)] &= ~(0x1 << OFF(pos)))
 
 	/* Forward definitions. */
 	extern void debug(const char *, const char *, ...);
+    extern unsigned bitmap_nset(uint32_t *, size_t);
+    extern unsigned bitmap_nclear(uint32_t *, size_t);
+    extern bit_t bitmap_first_free(uint32_t *, size_t);
+    extern bit_t bitmap_check_bit(uint32_t *, uint32_t);
 
 #endif /* NANVIX_UTILS_H_ */

--- a/src/libs/nanvix/mm/rmem.c
+++ b/src/libs/nanvix/mm/rmem.c
@@ -123,17 +123,22 @@ int memread(uint64_t addr, void *buf, size_t n)
 	if (buf == NULL)
 		return (-EINVAL);
 
-	/* Invalid read size. */
-	if (n > RMEM_BLOCK_SIZE)
-		return (-EINVAL);
+    /* Bad addr to read. */
+    if (addr % RMEM_BLOCK_SIZE != 0)
+        return (-EFAULT);
+
+    /* Bad size to read. */
+    if (n % RMEM_BLOCK_SIZE != 0)
+        return (-EFAULT);
 
 	/* Nothing to do. */
-	if (n == 0)
+    if (n == 0)
 		return (0);
 
 	/* Build operation header. */
 	msg.header.source = sys_get_node_num();
 	msg.header.opcode = RMEM_READ;
+
 	msg.blknum = addr;
 	msg.size = n;
 
@@ -173,9 +178,13 @@ int memwrite(uint64_t addr, const void *buf, size_t n)
 	if (buf == NULL)
 		return (-EINVAL);
 
-	/* Invalid write size. */
-	if (n > RMEM_BLOCK_SIZE)
-		return (-EINVAL);
+    /* Bad addr to read. */
+    if (addr % RMEM_BLOCK_SIZE != 0)
+        return (-EFAULT);
+
+    /* Bad size to read. */
+    if (n % RMEM_BLOCK_SIZE != 0)
+        return (-EFAULT);
 
 	/* Nothing to do. */
 	if (n == 0)

--- a/src/libs/nanvix/util/bitmap.c
+++ b/src/libs/nanvix/util/bitmap.c
@@ -1,0 +1,133 @@
+/*
+ * Copyright(C) 2011-2016 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ *
+ * This file is part of Nanvix.
+ *
+ * Nanvix is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nanvix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Nanvix. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <nanvix/utils.h>
+#include <nanvix/const.h>
+
+/**
+ * @brief Returns the number of bits that are set in a bitmap.
+ *
+ * @details Counts the number of bits that are set in a bitmap using a
+ *          bit-hacking algorithm from Stanford.
+ *
+ * @param bitmap Bitmap to be searched.
+ * @param size   Size (in bytes) of the bitmap.
+ *
+ * @returns The number of bits that are set in the bitmap.
+ */
+unsigned bitmap_nset(uint32_t *bitmap, size_t size)
+{
+	unsigned count; /* Number of bits set. */
+	uint32_t *idx;  /* Loop index.         */
+	uint32_t *end;  /* End of bitmap.      */
+	uint32_t chunk; /* Working chunk.      */
+
+	/* Count the number of bits set. */
+	count = 0;
+	end = (bitmap + (size >> 2));
+	for (idx = bitmap; idx < end; idx++)
+	{
+		chunk = *idx;
+
+		/*
+		 * Fast way for counting number of bits set in a bit map.
+		 * I have no idea how does it work. I just got it from here:
+		 * https://graphics.stanford.edu/~seander/bithacks.html
+		 */
+		chunk = chunk - ((chunk >> 1) & 0x55555555);
+		chunk = (chunk & 0x33333333) + ((chunk >> 2) & 0x33333333);
+		count += (((chunk + (chunk >> 4)) & 0x0F0F0F0F) * 0x01010101) >> 24;
+	}
+
+	return (count);
+}
+
+/**
+ * @brief Returns the number of bits that are cleared in a bitmap.
+ *
+ * @details Counts the number of bits that are cleared in a bitmap using a
+ *          bit-hacking algorithm from Stanford.
+ *
+ * @param bitmap Bitmap to be searched.
+ * @param size   Size (in bytes) of the bitmap.
+ *
+ * @returns The number of bits that are cleared in the bitmap.
+ */
+unsigned bitmap_nclear(uint32_t *bitmap, size_t size)
+{
+	return ((size << 3) - bitmap_nset(bitmap, size));
+}
+
+/**
+ * @brief Searches for the first free bit in a bitmap.
+ *
+ * @details Searches for the first free bit in a bitmap. In order to speedup
+ *          computation, bits are checked in chunks of 4 bytes.
+ *
+ * @param bitmap Bitmap to be searched.
+ * @param size   Size (in bytes) of the bitmap.
+ *
+ * @returns If a free bit is found, the number of that bit is returned. However,
+ *          if no free bit is found #BITMAP_FULL is returned instead.
+ */
+bit_t bitmap_first_free(uint32_t *bitmap, size_t size)
+{
+    uint32_t *max;          /* Bitmap bondary. */
+    register uint32_t off;  /* Bit offset.     */
+    register uint32_t *idx; /* Bit index.      */
+
+    idx = bitmap;
+    max = (idx + (size >> 2));
+
+    /* Find bit index. */
+    while (idx < max)
+    {
+		/* Index found. */
+		if (*idx != 0xffffffff)
+		{
+			off = 0;
+
+			/* Find offset. */
+			while (*idx & (0x1 << off))
+				off++;
+
+			return (((idx - bitmap) << 5) + off);
+		}
+
+		idx++;
+	}
+
+	return (BITMAP_FULL);
+}
+
+/**
+ * @brief Checks what is the value of the nth bit.
+ *
+ * @details Return the value of the bit on the nth position.
+ *
+ * @param bitmap Bitmap to be checked.
+ * @param idx Index of the bitmap to be checked.
+ *
+ * @returns The value of the bit in the idx position.
+ */
+bit_t bitmap_check_bit(uint32_t *bitmap, uint32_t idx)
+{
+	bit_t bit = (bitmap[idx >> 5] >> idx) & 1u;
+	return bit;
+}

--- a/src/ubin/test/master/nanvix/mm/rmem/fault.c
+++ b/src/ubin/test/master/nanvix/mm/rmem/fault.c
@@ -49,6 +49,8 @@ static void test_mm_rmem_invalid_write(void)
 	memset(buffer, 1, DATA_SIZE);
 	TEST_ASSERT(memwrite(RMEM_SIZE, buffer, DATA_SIZE) < 0);
 	TEST_ASSERT(memwrite(RMEM_SIZE - DATA_SIZE/2, buffer, DATA_SIZE) < 0);
+    TEST_ASSERT(memwrite(RMEM_BLOCK_SIZE/2, buffer, RMEM_SIZE/RMEM_BLOCK_SIZE) < 0);
+    TEST_ASSERT(memwrite(0, buffer, RMEM_BLOCK_SIZE/2) < 0);
 }
 
 /*============================================================================*
@@ -76,6 +78,8 @@ static void test_mm_rmem_invalid_write_size(void)
 
 	memset(buffer, 1, DATA_SIZE);
 	TEST_ASSERT(memwrite(0, buffer, RMEM_BLOCK_SIZE + 1) < 0);
+    TEST_ASSERT(memwrite(RMEM_BLOCK_SIZE/2, buffer, RMEM_SIZE/RMEM_BLOCK_SIZE) < 0);
+    TEST_ASSERT(memwrite(0, buffer, RMEM_BLOCK_SIZE/2) < 0);
 }
 
 /*============================================================================*
@@ -92,6 +96,8 @@ static void test_mm_rmem_invalid_read(void)
 	memset(buffer, 1, DATA_SIZE);
 	TEST_ASSERT(memread(RMEM_SIZE, buffer, DATA_SIZE) < 0);
 	TEST_ASSERT(memread(RMEM_SIZE - DATA_SIZE/2, buffer, DATA_SIZE) < 0);
+    TEST_ASSERT(memread(RMEM_BLOCK_SIZE/2, buffer, RMEM_SIZE/RMEM_BLOCK_SIZE) < 0);
+    TEST_ASSERT(memread(0, buffer, RMEM_BLOCK_SIZE/2) < 0);
 }
 
 /*============================================================================*
@@ -119,6 +125,20 @@ static void test_mm_rmem_invalid_read_size(void)
 
 	memset(buffer, 1, DATA_SIZE);
 	TEST_ASSERT(memread(0, buffer, RMEM_BLOCK_SIZE + 1) < 0);
+    TEST_ASSERT(memread(RMEM_BLOCK_SIZE/2, buffer, RMEM_SIZE/RMEM_BLOCK_SIZE) < 0);
+    TEST_ASSERT(memread(0, buffer, RMEM_BLOCK_SIZE/2) < 0);
+}
+
+/*============================================================================*
+ * API Test: Invalid Free                                                     *
+ *============================================================================*/
+
+/**
+ * @brief API Test: Invalid Free
+ */
+static void test_mm_rmem_invalid_free(void)
+{
+    TEST_ASSERT(memfree(RMEM_SIZE/RMEM_BLOCK_SIZE) < 0);
 }
 
 /*============================================================================*/
@@ -133,5 +153,6 @@ struct test mm_rmem_tests_fault[] = {
 	{ test_mm_rmem_invalid_read,       "Invalid Read"       },
 	{ test_mm_rmem_null_read,          "Null Read"          },
 	{ test_mm_rmem_invalid_read_size,  "Invalid Read Size"  },
+	{ test_mm_rmem_invalid_free,       "Invalid Free"       },
 	{ NULL,                            NULL                 },
 };

--- a/src/ubin/test/master/nanvix/mm/rmem/fault.c
+++ b/src/ubin/test/master/nanvix/mm/rmem/fault.c
@@ -138,6 +138,7 @@ static void test_mm_rmem_invalid_read_size(void)
  */
 static void test_mm_rmem_invalid_free(void)
 {
+    TEST_ASSERT(memfree(-1) < 0);
     TEST_ASSERT(memfree(RMEM_SIZE/RMEM_BLOCK_SIZE) < 0);
 }
 

--- a/src/ubin/test/master/nanvix/mm/rmem/fault.c
+++ b/src/ubin/test/master/nanvix/mm/rmem/fault.c
@@ -35,6 +35,11 @@
  */
 #define TEST_ASSERT(x) { if (!(x)) exit(EXIT_FAILURE); }
 
+/**
+ * @brief Invalid alloc test flag.
+ */
+#define TEST_INV_ALLOC 0
+
 /*============================================================================*
  * API Test: Invalid Write                                                    *
  *============================================================================*/
@@ -130,6 +135,25 @@ static void test_mm_rmem_invalid_read_size(void)
 }
 
 /*============================================================================*
+ * API Test: Invalid Alloc                                                    *
+ *============================================================================*/
+
+/**
+ * @brief API Test: Invalid Alloc
+ */
+static void test_mm_rmem_invalid_alloc(void)
+{
+    if (TEST_INV_ALLOC)
+    {
+        for (int i = 0; i < RMEM_SIZE/RMEM_BLOCK_SIZE; i++)
+        {
+            TEST_ASSERT(memalloc() == i);
+        }
+        TEST_ASSERT(memalloc() < 0);
+    }
+}
+
+/*============================================================================*
  * API Test: Invalid Free                                                     *
  *============================================================================*/
 
@@ -155,5 +179,6 @@ struct test mm_rmem_tests_fault[] = {
 	{ test_mm_rmem_null_read,          "Null Read"          },
 	{ test_mm_rmem_invalid_read_size,  "Invalid Read Size"  },
 	{ test_mm_rmem_invalid_free,       "Invalid Free"       },
+	{ test_mm_rmem_invalid_alloc,      "Invalid Alloc"      },
 	{ NULL,                            NULL                 },
 };

--- a/src/ubin/test/master/posix/shm/api.c
+++ b/src/ubin/test/master/posix/shm/api.c
@@ -181,11 +181,13 @@ static void test_posix_shm_map_unmap1(void)
 	char shm_name[SHM_NAME_MAX];
 
 	sprintf(shm_name, "/shm");
+    TEST_ASSERT(memalloc() == 0);
 	TEST_ASSERT((shm = shm_open(shm_name, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, REGION_SIZE) == 0);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_READ, MAP_PRIVATE, shm, 0)) != MAP_FAILED);
 	TEST_ASSERT(munmap(map, REGION_SIZE) == 0);
 	TEST_ASSERT(shm_unlink(shm_name) == 0);
+    TEST_ASSERT(memfree(0) == 0);
 }
 
 /*==========================================================================*
@@ -202,11 +204,13 @@ static void test_posix_shm_map_unmap2(void)
 	char shm_name[SHM_NAME_MAX];
 
 	sprintf(shm_name, "/shm");
+    TEST_ASSERT(memalloc() == 0);
 	TEST_ASSERT((shm = shm_open(shm_name, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, REGION_SIZE) == 0);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_WRITE, MAP_PRIVATE, shm, 0)) != MAP_FAILED);
 	TEST_ASSERT(munmap(map, REGION_SIZE) == 0);
 	TEST_ASSERT(shm_unlink(shm_name) == 0);
+    TEST_ASSERT(memfree(0) == 0);
 }
 
 /*==========================================================================*
@@ -223,11 +227,13 @@ static void test_posix_shm_map_unmap3(void)
 	char shm_name[SHM_NAME_MAX];
 
 	sprintf(shm_name, "/shm");
+    TEST_ASSERT(memalloc() == 0);
 	TEST_ASSERT((shm = shm_open(shm_name, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, REGION_SIZE) == 0);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_READ, MAP_SHARED, shm, 0)) != MAP_FAILED);
 	TEST_ASSERT(munmap(map, REGION_SIZE) == 0);
 	TEST_ASSERT(shm_unlink(shm_name) == 0);
+    TEST_ASSERT(memfree(0) == 0);
 }
 
 /*==========================================================================*
@@ -244,11 +250,13 @@ static void test_posix_shm_map_unmap4(void)
 	char shm_name[SHM_NAME_MAX];
 
 	sprintf(shm_name, "/shm");
+    TEST_ASSERT(memalloc() == 0);
 	TEST_ASSERT((shm = shm_open(shm_name, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, REGION_SIZE) == 0);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_WRITE, MAP_SHARED, shm, 0)) != MAP_FAILED);
 	TEST_ASSERT(munmap(map, REGION_SIZE) == 0);
 	TEST_ASSERT(shm_unlink(shm_name) == 0);
+    TEST_ASSERT(memfree(0) == 0);
 }
 
 /*==========================================================================*
@@ -265,11 +273,14 @@ static void test_posix_shm_map_unmap5(void)
 	char shm_name[SHM_NAME_MAX];
 
 	sprintf(shm_name, "/shm");
+    TEST_ASSERT(memalloc() == 0);
+    TEST_ASSERT(memalloc() == 1);
 	TEST_ASSERT((shm = shm_open(shm_name, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, 2*REGION_SIZE) == 0);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_READ, MAP_PRIVATE, shm, REGION_SIZE)) != MAP_FAILED);
 	TEST_ASSERT(munmap(map, REGION_SIZE) == 0);
 	TEST_ASSERT(shm_unlink(shm_name) == 0);
+    TEST_ASSERT(memfree(0) == 0);
 }
 
 /*==========================================================================*
@@ -286,11 +297,13 @@ static void test_posix_shm_map_unmap6(void)
 	char shm_name[SHM_NAME_MAX];
 
 	sprintf(shm_name, "/shm");
+    TEST_ASSERT(memalloc() == 0);
 	TEST_ASSERT((shm = shm_open(shm_name, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, 2*REGION_SIZE) == 0);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_WRITE, MAP_PRIVATE, shm, REGION_SIZE)) != MAP_FAILED);
 	TEST_ASSERT(munmap(map, REGION_SIZE) == 0);
 	TEST_ASSERT(shm_unlink(shm_name) == 0);
+    TEST_ASSERT(memfree(0) == 0);
 }
 
 /*==========================================================================*
@@ -307,11 +320,13 @@ static void test_posix_shm_map_unmap7(void)
 	char shm_name[SHM_NAME_MAX];
 
 	sprintf(shm_name, "/shm");
+    TEST_ASSERT(memalloc() == 0);
 	TEST_ASSERT((shm = shm_open(shm_name, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, 2*REGION_SIZE) == 0);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_READ, MAP_SHARED, shm, REGION_SIZE)) != MAP_FAILED);
 	TEST_ASSERT(munmap(map, REGION_SIZE) == 0);
 	TEST_ASSERT(shm_unlink(shm_name) == 0);
+    TEST_ASSERT(memfree(0) == 0);
 }
 
 /*==========================================================================*
@@ -328,11 +343,13 @@ static void test_posix_shm_map_unmap8(void)
 	char shm_name[SHM_NAME_MAX];
 
 	sprintf(shm_name, "/shm");
+    TEST_ASSERT(memalloc() == 0);
 	TEST_ASSERT((shm = shm_open(shm_name, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, 2*REGION_SIZE) == 0);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_WRITE, MAP_SHARED, shm, REGION_SIZE)) != MAP_FAILED);
 	TEST_ASSERT(munmap(map, REGION_SIZE) == 0);
 	TEST_ASSERT(shm_unlink(shm_name) == 0);
+    TEST_ASSERT(memfree(0) == 0);
 }
 /*==========================================================================*
  * API Test: Map_Unmap 9                                                    *
@@ -348,6 +365,7 @@ static void test_posix_shm_map_unmap9(void)
 	char shm_name[SHM_NAME_MAX];
 
 	sprintf(shm_name, "/shm");
+    TEST_ASSERT(memalloc() == 0);
 	TEST_ASSERT((shm = shm_open(shm_name, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, REGION_SIZE) == 0);
 	TEST_ASSERT((map1 = mmap(NULL, REGION_SIZE, PROT_WRITE, MAP_SHARED, shm, 0)) != MAP_FAILED);
@@ -355,6 +373,7 @@ static void test_posix_shm_map_unmap9(void)
 	TEST_ASSERT((map2 = mmap(NULL, REGION_SIZE, PROT_WRITE, MAP_SHARED, shm, 0)) != MAP_FAILED);
 	TEST_ASSERT(munmap(map2, REGION_SIZE) == 0);
 	TEST_ASSERT(shm_unlink(shm_name) == 0);
+    TEST_ASSERT(memfree(0) == 0);
 }
 
 /*==========================================================================*
@@ -371,6 +390,7 @@ static void test_posix_shm_sync1(void)
 	char shm_name[SHM_NAME_MAX];
 
 	sprintf(shm_name, "/shm");
+    TEST_ASSERT(memalloc() == 0);
 	TEST_ASSERT((shm = shm_open(shm_name, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, REGION_SIZE) == 0);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_WRITE, MAP_SHARED, shm, 0)) != MAP_FAILED);
@@ -381,6 +401,7 @@ static void test_posix_shm_sync1(void)
 
 	TEST_ASSERT(munmap(map, REGION_SIZE) == 0);
 	TEST_ASSERT(shm_unlink(shm_name) == 0);
+    TEST_ASSERT(memfree(0) == 0);
 }
 
 /*==========================================================================*
@@ -397,6 +418,7 @@ static void test_posix_shm_sync2(void)
 	char shm_name[SHM_NAME_MAX];
 
 	sprintf(shm_name, "/shm");
+    TEST_ASSERT(memalloc() == 0);
 	TEST_ASSERT((shm = shm_open(shm_name, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, REGION_SIZE) == 0);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_WRITE, MAP_SHARED, shm, 0)) != MAP_FAILED);
@@ -415,6 +437,7 @@ static void test_posix_shm_sync2(void)
 
 	TEST_ASSERT(munmap(map, REGION_SIZE) == 0);
 	TEST_ASSERT(shm_unlink(shm_name) == 0);
+    TEST_ASSERT(memfree(0) == 0);
 }
 
 /*============================================================================*/

--- a/src/ubin/test/master/posix/shm/fault.c
+++ b/src/ubin/test/master/posix/shm/fault.c
@@ -56,7 +56,7 @@ static void test_posix_shm_invalid_create(void)
  *============================================================================*/
 
 /**
- * @brief Fault Injection Test: Bad Create 
+ * @brief Fault Injection Test: Bad Create
  */
 static void test_posix_shm_bad_create(void)
 {
@@ -69,7 +69,7 @@ static void test_posix_shm_bad_create(void)
  *============================================================================*/
 
 /**
- * @brief Fault Injection Test: Double Create 
+ * @brief Fault Injection Test: Double Create
  */
 static void test_posix_shm_double_create(void)
 {
@@ -104,7 +104,7 @@ static void test_posix_shm_invalid_open(void)
  *============================================================================*/
 
 /**
- * @brief Fault Injection Test: Bad Open 
+ * @brief Fault Injection Test: Bad Open
  */
 static void test_posix_shm_bad_open(void)
 {
@@ -136,7 +136,7 @@ static void test_posix_shm_invalid_unlink(void)
  *============================================================================*/
 
 /**
- * @brief Fault Injection Test: Bad Unlink 
+ * @brief Fault Injection Test: Bad Unlink
  */
 static void test_posix_shm_bad_unlink(void)
 {
@@ -149,7 +149,7 @@ static void test_posix_shm_bad_unlink(void)
  *============================================================================*/
 
 /**
- * @brief Fault Injection Test: Double Unlink 
+ * @brief Fault Injection Test: Double Unlink
  */
 static void test_posix_shm_double_unlink(void)
 {
@@ -190,17 +190,21 @@ static void test_posix_shm_bad_truncate(void)
 	int shm;
 	void *map;
 
+    TEST_ASSERT(memalloc() == 0);
 	TEST_ASSERT((shm = shm_open("/shm", O_CREAT | O_RDONLY, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, REGION_SIZE) < 0);
 	TEST_ASSERT(ftruncate(1, REGION_SIZE) < 0);
 	TEST_ASSERT(shm_unlink("/shm") == 0);
+    TEST_ASSERT(memfree(0) == 0);
 
+    TEST_ASSERT(memalloc() == 0);
 	TEST_ASSERT((shm = shm_open("/shm", O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, REGION_SIZE) == 0);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_READ, MAP_PRIVATE, shm, 0)) != MAP_FAILED);
 	TEST_ASSERT(ftruncate(shm, 2*REGION_SIZE) < 0);
 	TEST_ASSERT(munmap(map, REGION_SIZE) == 0);
 	TEST_ASSERT(shm_unlink("/shm") == 0);
+    TEST_ASSERT(memfree(0) == 0);
 }
 
 /*============================================================================*
@@ -215,6 +219,7 @@ static void test_posix_shm_invalid_map(void)
 	int shm;
 	void *map;
 
+    TEST_ASSERT(memalloc() == 0);
 	TEST_ASSERT((shm = shm_open("/shm", O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT((map = mmap(NULL, 0, PROT_READ, MAP_PRIVATE, shm, 0)) == MAP_FAILED);
 	TEST_ASSERT(ftruncate(shm, REGION_SIZE) == 0);
@@ -224,6 +229,7 @@ static void test_posix_shm_invalid_map(void)
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, 0, MAP_PRIVATE, shm, 0)) == MAP_FAILED);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_READ, 0, shm, 0)) == MAP_FAILED);
 	TEST_ASSERT(shm_unlink("/shm") == 0);
+    TEST_ASSERT(memfree(0) == 0);
 }
 
 /*============================================================================*
@@ -238,10 +244,12 @@ static void test_posix_shm_bad_map(void)
 	int shm;
 	void *map;
 
+    TEST_ASSERT(memalloc() == 0);
 	TEST_ASSERT((shm = shm_open("/shm", O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, REGION_SIZE) == 0);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_READ, MAP_PRIVATE, 1, 0)) == MAP_FAILED);
 	TEST_ASSERT(shm_unlink("/shm") == 0);
+    TEST_ASSERT(memfree(0) == 0);
 }
 
 /*============================================================================*
@@ -256,6 +264,7 @@ static void test_posix_shm_invalid_unmap(void)
 	int shm;
 	void *map;
 
+    TEST_ASSERT(memalloc() == 0);
 	TEST_ASSERT((shm = shm_open("/shm", O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, REGION_SIZE) == 0);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_READ, MAP_PRIVATE, shm, 0)) != MAP_FAILED);
@@ -265,6 +274,7 @@ static void test_posix_shm_invalid_unmap(void)
 	TEST_ASSERT(munmap(map, REGION_SIZE + 1) < 0);
 	TEST_ASSERT(munmap(map, REGION_SIZE) == 0);
 	TEST_ASSERT(shm_unlink("/shm") == 0);
+    TEST_ASSERT(memfree(0) == 0);
 }
 
 /*============================================================================*
@@ -279,6 +289,7 @@ static void test_posix_shm_bad_unmap(void)
 	int shm;
 	void *map;
 
+    TEST_ASSERT(memalloc() == 0);
 	TEST_ASSERT((shm = shm_open("/shm", O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, REGION_SIZE) == 0);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_READ, MAP_PRIVATE, shm, 0)) != MAP_FAILED);
@@ -286,6 +297,7 @@ static void test_posix_shm_bad_unmap(void)
 	TEST_ASSERT(munmap(map, REGION_SIZE/2) < 0);
 	TEST_ASSERT(munmap(map, REGION_SIZE) == 0);
 	TEST_ASSERT(shm_unlink("/shm") == 0);
+    TEST_ASSERT(memfree(0) == 0);
 }
 
 /*============================================================================*
@@ -300,6 +312,7 @@ static void test_posix_shm_invalid_sync(void)
 	int shm;
 	void *map;
 
+    TEST_ASSERT(memalloc() == 0);
 	TEST_ASSERT((shm = shm_open("/shm", O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, REGION_SIZE) == 0);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_WRITE, MAP_SHARED, shm, 0)) != MAP_FAILED);
@@ -314,6 +327,7 @@ static void test_posix_shm_invalid_sync(void)
 
 	TEST_ASSERT(munmap(map, REGION_SIZE) == 0);
 	TEST_ASSERT(shm_unlink("/shm") == 0);
+    TEST_ASSERT(memfree(0) == 0);
 }
 
 /*============================================================================*
@@ -328,6 +342,7 @@ static void test_posix_shm_bad_sync(void)
 	int shm;
 	void *map;
 
+    TEST_ASSERT(memalloc() == 0);
 	TEST_ASSERT((shm = shm_open("/shm", O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, REGION_SIZE) == 0);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_WRITE, MAP_SHARED, shm, 0)) != MAP_FAILED);
@@ -335,7 +350,9 @@ static void test_posix_shm_bad_sync(void)
 	TEST_ASSERT(msync((void *)test_posix_shm_bad_sync, REGION_SIZE, MS_SYNC) < 0);
 	TEST_ASSERT(munmap(map, REGION_SIZE) == 0);
 	TEST_ASSERT(shm_unlink("/shm") == 0);
+    TEST_ASSERT(memfree(0) == 0);
 
+    TEST_ASSERT(memalloc() == 0);
 	TEST_ASSERT((shm = shm_open("/shm", O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)) >= 0);
 	TEST_ASSERT(ftruncate(shm, REGION_SIZE) == 0);
 	TEST_ASSERT((map = mmap(NULL, REGION_SIZE, PROT_READ, MAP_SHARED, shm, 0)) != MAP_FAILED);
@@ -343,6 +360,7 @@ static void test_posix_shm_bad_sync(void)
 	TEST_ASSERT(msync(map, REGION_SIZE, MS_SYNC) < 0);
 	TEST_ASSERT(munmap(map, REGION_SIZE) == 0);
 	TEST_ASSERT(shm_unlink("/shm") == 0);
+    TEST_ASSERT(memfree(0) == 0);
 }
 
 /*============================================================================*
@@ -356,21 +374,27 @@ static void test_posix_shm_invalid_oflags(void)
 {
 	int shm;
 
+    TEST_ASSERT(memalloc() == 0);
 	TEST_ASSERT((shm = shm_open("cool-name", O_CREAT, 0)) >= 0);
 	TEST_ASSERT(shm_open("cool-name", O_CREAT, 0) < 0);
 	TEST_ASSERT(shm_open("cool-name", O_RDONLY, 0) < 0);
 	TEST_ASSERT(shm_open("cool-name", O_RDWR, 0) < 0);
 	TEST_ASSERT(shm_unlink("cool-name") == 0);
+    TEST_ASSERT(memfree(0) == 0);
 
+    TEST_ASSERT(memalloc() == 0);
 	TEST_ASSERT((shm = shm_open("cool-name2", O_CREAT, S_IRUSR)) >= 0);
 	TEST_ASSERT(shm_open("cool-name2", O_RDWR, 0) < 0);
 	TEST_ASSERT(shm_unlink("cool-name2") == 0);
+    TEST_ASSERT(memfree(0) == 0);
 
+    TEST_ASSERT(memalloc() == 0);
 	TEST_ASSERT((shm = shm_open("cool-name3", O_CREAT, S_IWUSR)) >= 0);
 	TEST_ASSERT(shm_open("cool-name3", O_CREAT, 0) < 0);
 	TEST_ASSERT(shm_open("cool-name3", O_RDONLY, 0) < 0);
 	TEST_ASSERT(shm_open("cool-name3", O_RDWR, 0) < 0);
 	TEST_ASSERT(shm_unlink("cool-name3") == 0);
+    TEST_ASSERT(memfree(0) == 0);
 }
 
 /*============================================================================*/


### PR DESCRIPTION
# Description
In this PR, I introduce new test units to support the correctness of alloc and free features ([[rmem] Remote Memory Allocation](https://github.com/nanvix/multikernel/issues/100)). More precisely, the tests comprehend failure prone situations and clusters using alloc and free features.

Moreover, new verification were added to improve execution correctness.

# Related Issues
[[test] Unit Tests for RMem Server](https://github.com/nanvix/multikernel/issues/146)