### PR TITLE
[barrier] Bad Node Check

### DIFF
--- a/src/libs/nanvix/ipc/barrier.c
+++ b/src/libs/nanvix/ipc/barrier.c
@@ -208,7 +208,7 @@ found:
 		/* Check for a bad barrier leader. */
 		for (int i = 1; i < nnodes; i++)
 		{
-			if (nodenum < nodes[i])
+			if (nodenum == nodes[i])
 				goto error0;
 		}
 


### PR DESCRIPTION
# Description
In this PR, I modified the bad node comparison in the barrier creation. It had a bug where the comparison made to identify the master node was incorrect.