### PR TITLE
[rmem] Remote Memory Cache

### DIFF
--- a/include/nanvix/runtime/rmem.h
+++ b/include/nanvix/runtime/rmem.h
@@ -1,0 +1,122 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2019 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef NANVIX_RUNTIME_RMEM_H_
+#define NANVIX_RUNTIME_RMEM_H_
+
+#if defined(__NEED_RMEM_CACHE)
+
+	#define __NEED_RMEM_CLIENT
+
+#endif /* NANVIX_RUNTIME_RMEM_H_ */
+
+	#include <nanvix/servers/rmem.h>
+	#include <stddef.h>
+
+#if defined(__NEED_RMEM_CACHE)
+
+	/**
+	 * @name Page replacement policies.
+	 */
+	/**@{*/
+	#define RMEM_CACHE_FIFO 0 /**< First In First Out  */
+	#define RMEM_CACHE_LIFO 1 /**< Last In First Out   */
+	#define RMEM_CACHE_LRU  2 /**< Least Recently Used */
+	/**@}*/
+
+	/**
+	 * @name Page Writing Policies
+	 */
+	/**@{*/
+	#define RMEM_CACHE_WRITE_BACK    0 /**< Write Back    */
+	#define RMEM_CACHE_WRITE_THROUGH 1 /**< Write Through */
+	/**@}*/
+
+	/**
+	 * @brief Allocates a remote page.
+	 *
+	 * @returns Upon successful completion, the number of the newly
+	 * allocated remote page is returned. Upon failure, @p RMEM_NULL
+	 * is returned instead.
+	 */
+	extern rpage_t nanvix_rcache_alloc(void);
+
+	/**
+	 * @brief Frees a remote page.
+	 *
+	 * @param pgnum Number of the target page.
+	 *
+	 * @returns Upon successful completion, zero is returned. Upon
+	 * failure, a negative error code is returned instead.
+	 */
+	extern int nanvix_rcache_free(rpage_t pgnum);
+
+	/**
+	 * @brief Gets remote page.
+	 *
+	 * @param pgnum Number of the target page.
+	 *
+	 * @returns Upon successful completion, a pointer to a local
+	 * mapping of the remote page is returned. Upon failure, a @p
+	 * NULL pointer is returned instead.
+	 */
+	extern void *nanvix_rcache_get(rpage_t pgnum);
+
+	/**
+	 * @brief Puts remote page.
+	 *
+	 * @param pgnum Number of the target page.
+	 *
+	 * @returns Upon successful completion, zero is returned. Upon failure a
+	 * negative error code is returned instead.
+	 */
+	extern int nanvix_rcache_put(rpage_t pgnum);
+
+	/**
+	 * @brief Flushes changes on a remote page.
+	 *
+	 * @param pgnum Number of the target page.
+	 *
+	 * @returns Upon successful completion, zero is returned. Upon
+	 * failure a negative error code is returned instead.
+	 */
+	extern int nanvix_rcache_flush(rpage_t pgnum);
+
+	/**
+	 * @brief Selects the cache replacement_policy.
+	 *
+	 * @param num Number of the replacement policy.
+	 */
+	extern int nanvix_rcache_select_replacement_policy(int num);
+
+	/**
+	 * @brief Selects the write policy.
+	 *
+	 * @param num Number of the policy.
+	 */
+	extern int nanvix_rcache_select_write(int num);
+
+#endif /* __NEED_RMEM_CACHE */
+
+#endif /* NANVIX_RUNTIME_RMEM_H_ */

--- a/src/libruntime/rmem/cache.c
+++ b/src/libruntime/rmem/cache.c
@@ -1,0 +1,442 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2019 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#define __NEED_RMEM_CLIENT
+#define __NEED_RMEM_CACHE
+
+#include <nanvix/runtime/rmem.h>
+#include <ulibc/string.h>
+#include <ulibc/stdio.h>
+#include <posix/errno.h>
+
+/**
+ * @brief Page cache length.
+ */
+#define RMEM_CACHE_LENGTH 5
+
+/**
+ * @brief Page cache.
+ */
+typedef struct
+{
+	rpage_t pgnum;
+	char pages[RMEM_BLOCK_SIZE];
+	int age;
+	int ref_count;
+} cache_slot;
+
+static cache_slot cache_lines[RMEM_CACHE_LENGTH] = {
+	[0 ... (RMEM_CACHE_LENGTH - 1)] = {.pgnum = RMEM_NULL, .age = 0, .ref_count = 0}
+};
+
+static int time_cache = 0;
+static int cache_policy = RMEM_CACHE_FIFO;
+static int write_num = RMEM_CACHE_WRITE_BACK;
+
+/*============================================================================*
+ * nanvix_rcache_page_search()                                                *
+ *============================================================================*/
+
+/**
+ * @brief Searches for a page in the cache.
+ *
+ * @param pgnum Number of the target page.
+ *
+ * @returns Upon successful completion, the page index is
+ * returned. Upon failure a negative error code is returned instead.
+ */
+static int nanvix_rcache_page_search(rpage_t pgnum)
+{
+	time_cache++;
+
+	for (int i = 0; i < RMEM_CACHE_LENGTH; i++)
+	{
+		if (cache_lines[i].pgnum == pgnum)
+		    return (i);
+	}
+
+	return (-EFAULT);
+}
+
+/*============================================================================*
+ * nanvix_rcache_age_update_lru()                                             *
+ *============================================================================*/
+
+/**
+ * @brief Evicts pages from the cache based on the LRU replacement policy.
+ *
+ * @param pgnum Number of the target page.
+ *
+ * @returns Upon successful completion, the index of the page is
+ * returned. Upon failure a negative error code is returned instead.
+ */
+static int nanvix_rcache_age_update_lru(rpage_t pgnum)
+{
+	int idx;
+
+	time_cache++;
+
+	if (cache_policy == RMEM_CACHE_LRU)
+	{
+		if ((idx = nanvix_rcache_page_search(pgnum)) < 0)
+		    return (-EFAULT);
+
+		cache_lines[idx].age = time_cache;
+	}
+
+	return (0);
+}
+
+/*============================================================================*
+ * nanvix_rcache_age_update()                                                 *
+ *============================================================================*/
+
+/**
+ * @todo TODO: provide a detailed description for this function.
+ */
+static int nanvix_rcache_age_update(rpage_t pgnum)
+{
+	int idx;
+
+	time_cache++;
+
+	if ((idx = nanvix_rcache_page_search(pgnum)) < 0)
+		return (-EFAULT);
+
+	cache_lines[idx].age = time_cache;
+	return 0;
+}
+
+/*============================================================================*
+ * nanvix_rcache_fifo()                                                       *
+ *============================================================================*/
+
+/**
+ * @brief Evicts pages from the cache based on the FIFO replacement policy.
+ *
+ * @param pgnum Number of the target page.
+ *
+ * @returns Upon successful completion, the index of the page is
+ * returned. Upon failure a negative error code is returned instead.
+ */
+static int nanvix_rcache_fifo(void)
+{
+	int idx;
+	int age;
+	int min_age;
+
+	time_cache++;
+
+	/* Cache has space. */
+	for (int i = 0; i < RMEM_CACHE_LENGTH; i++)
+	{
+		if (cache_lines[i].pgnum == RMEM_NULL)
+		    return (i);
+	}
+
+	/* No space. Make evict. */
+	min_age = cache_lines[idx = 0].age;
+	for (int i = 1; i < RMEM_CACHE_LENGTH; i++)
+	{
+		if ((age = cache_lines[i].age) < min_age)
+		{
+		    idx = i;
+		    min_age = age;
+		}
+	}
+
+	if (nanvix_rcache_flush(cache_lines[idx].pgnum) < 0)
+		return (-EFAULT);
+
+	return (idx);
+}
+
+/*============================================================================*
+ * nanvix_rcache_lru()                                                        *
+ *============================================================================*/
+
+/**
+ * @todo TODO: provide a detailed description for this function.
+ */
+static int nanvix_rcache_lru(void)
+{
+	return (nanvix_rcache_fifo());
+}
+
+/*============================================================================*
+ * nanvix_rcache_lifo()                                                       *
+ *============================================================================*/
+
+/**
+ * @brief Evicts pages from the cache based on the LIFO replacement policy.
+ *
+ * @param pgnum Number of the target page.
+ *
+ * @returns Upon successful completion, the index of the page is
+ * returned. Upon failure a negative error code is returned instead.
+ */
+static int nanvix_rcache_lifo(void)
+{
+	int idx;
+	int age;
+	int max_age;
+
+	time_cache++;
+
+	/* Cache has space. */
+	for (int i = 0; i < RMEM_CACHE_LENGTH; i++)
+	{
+		if (cache_lines[i].pgnum == RMEM_NULL)
+		    return (i);
+	}
+
+	/* No space. Make evict. */
+	max_age = cache_lines[idx = 0].age;
+	for (int i = 1; i < RMEM_CACHE_LENGTH; i++)
+	{
+		if ((age = cache_lines[i].age) > max_age)
+		{
+		    idx = i;
+		    max_age = age;
+		}
+	}
+
+	if (nanvix_rcache_flush(cache_lines[idx].pgnum) < 0)
+		return (-EFAULT);
+
+	return idx;
+}
+
+/*============================================================================*
+ * nanvix_rcache_replacement_policies()                                       *
+ *============================================================================*/
+
+/**
+ * @brief Selects the replacement policy function based on the
+ * replacement policy number.
+ *
+ * @returns Upon successful completion, the free index of a page is
+ * returned. Upon failure a negative error code is returned instead.
+ */
+static int nanvix_rcache_replacement_policies(void)
+{
+	if (cache_policy == RMEM_CACHE_FIFO)
+		return (nanvix_rcache_fifo());
+
+	if (cache_policy == RMEM_CACHE_LIFO)
+		return (nanvix_rcache_lifo());
+
+	return (nanvix_rcache_lru());
+}
+
+/*============================================================================*
+ * nanvix_rcache_select_replacement_policy()                                  *
+ *============================================================================*/
+
+/**
+ * @todo TODO: provide a detailed description for this function.
+ */
+int nanvix_rcache_select_replacement_policy(int num)
+{
+	time_cache++;
+
+	switch (num)
+	{
+		case RMEM_CACHE_FIFO:
+		case RMEM_CACHE_LIFO:
+		case RMEM_CACHE_LRU:
+			cache_policy = num;
+			break;
+		default:
+			return (-EFAULT);
+	}
+	return (0);
+}
+
+/*============================================================================*
+ * nanvix_rcache_select_write()                                               *
+ *============================================================================*/
+
+/**
+ * @todo TODO: provide a detailed description for this function.
+ */
+int nanvix_rcache_select_write(int num)
+{
+	time_cache++;
+
+	switch (num)
+	{
+		case RMEM_CACHE_WRITE_THROUGH:
+		case RMEM_CACHE_WRITE_BACK:
+			cache_policy = num;
+			break;
+		default:
+			return (-EFAULT);
+	}
+	return (0);
+}
+
+/*============================================================================*
+ * nanvix_rcache_ralloc()                                                     *
+ *============================================================================*/
+
+/**
+ * @todo TODO: provide a detailed description for this function.
+ */
+rpage_t nanvix_rcache_alloc(void)
+{
+	rpage_t pgnum;
+
+	time_cache++;
+
+	/* Forward allocation to remote memory. */
+	if ((pgnum = nanvix_rmem_alloc()) == (rpage_t) -ENOMEM)
+		return (RMEM_NULL);
+
+	return (pgnum);
+}
+
+/*============================================================================*
+ * nanvix_rcache_flush()                                                      *
+ *============================================================================*/
+
+/**
+ * @todo TODO: provide a detailed description for this function.
+ */
+int nanvix_rcache_flush(rpage_t pgnum)
+{
+	int err;
+	int idx;
+
+	time_cache++;
+
+	/* Invalid page number. */
+	if ((pgnum == RMEM_NULL) || (RMEM_BLOCK_NUM(pgnum) >= RMEM_NUM_BLOCKS))
+		return (-EFAULT);
+
+	/* Sarch for page in the cache. */
+	if ((idx = nanvix_rcache_page_search(pgnum)) < 0)
+		return (-EFAULT);
+
+	/* Write page back to remote memory. */
+	if ((err = nanvix_rmem_write(pgnum, cache_lines[idx].pages)) < 0)
+		return (err);
+
+	return (0);
+}
+
+/*============================================================================*
+ * nanvix_rcache_free()                                                       *
+ *============================================================================*/
+
+/**
+ * @todo TODO: provide a detailed description for this function.
+ */
+int nanvix_rcache_free(rpage_t pgnum)
+{
+	time_cache++;
+
+	/* Invalid page number. */
+	if ((pgnum == RMEM_NULL) || (RMEM_BLOCK_NUM(pgnum) >= RMEM_NUM_BLOCKS))
+		return (-EFAULT);
+
+	/* Check if target page is loaded into the cache. */
+	for (int i = 0; i < RMEM_CACHE_LENGTH; i++)
+	{
+		if (cache_lines[i].pgnum == pgnum)
+		    cache_lines[i].pgnum = RMEM_NULL;
+	}
+
+	return (nanvix_rmem_free(pgnum));
+}
+
+/*============================================================================*
+ * nanvix_rcache_get()                                                        *
+ *============================================================================*/
+
+/**
+ * @todo TODO: provide a detailed description for this function.
+ */
+void *nanvix_rcache_get(rpage_t pgnum)
+{
+	int err;
+	int idx;
+
+	time_cache++;
+
+	/* Invalid page number. */
+	if ((pgnum == RMEM_NULL) || (RMEM_BLOCK_NUM(pgnum) >= RMEM_NUM_BLOCKS))
+		return (NULL);
+
+	if ((idx = nanvix_rcache_page_search(pgnum)) >= 0)
+	{
+		nanvix_rcache_age_update_lru(pgnum);
+		cache_lines[idx].ref_count++;
+		return (cache_lines[idx].pages);
+	}
+
+	if ((idx = nanvix_rcache_replacement_policies()) < 0)
+		return (NULL);
+
+	/* Load page remote page. */
+	if ((err = nanvix_rmem_read(pgnum, cache_lines[idx].pages)) < 0)
+		return (NULL);
+
+	cache_lines[idx].pgnum = pgnum;
+	cache_lines[idx].ref_count++;
+	nanvix_rcache_age_update(pgnum);
+
+	return (cache_lines[idx].pages);
+}
+
+/*============================================================================*
+ * nanvix_rcache_put()                                                        *
+ *============================================================================*/
+
+/**
+ * @todo TODO: provide a detailed description for this function.
+ */
+int nanvix_rcache_put(rpage_t pgnum)
+{
+	int idx;
+
+	time_cache++;
+
+	/* Invalid page number. */
+	if ((pgnum == RMEM_NULL) || (RMEM_BLOCK_NUM(pgnum) >= RMEM_NUM_BLOCKS))
+		return (-EFAULT);
+
+	if ((idx = nanvix_rcache_page_search(pgnum)) < 0)
+		return (-EFAULT);
+
+	if (cache_lines[idx].ref_count <= 0)
+		return (-EFAULT);
+
+	if ((write_num == RMEM_CACHE_WRITE_THROUGH) && (nanvix_rcache_flush(pgnum) < 0))
+		return (-EFAULT);
+
+	cache_lines[idx].ref_count--;
+
+	return (0);
+}

--- a/src/test/main.c
+++ b/src/test/main.c
@@ -52,6 +52,7 @@ int __main2(int argc, const char *argv[])
 
 		__runtime_setup(3);
 		test_rmem();
+		test_rmem_cache();
 
 		nanvix_printf("[nanvix][test] shutting down server\n");
 		nanvix_assert(stdsync_fence() == 0);

--- a/src/test/makefile
+++ b/src/test/makefile
@@ -40,7 +40,8 @@ EXEC = nanvix-test
 # C Source Files
 SRC = $(wildcard *.c)              \
       $(wildcard name/*.c)         \
-      $(wildcard rmem/manager/*.c)
+      $(wildcard rmem/manager/*.c) \
+      $(wildcard rmem/cache/*.c)
 
 # Object Files
 OBJ = $(SRC:.c=.$(OBJ_SUFFIX).o)

--- a/src/test/rmem/cache/api.c
+++ b/src/test/rmem/cache/api.c
@@ -1,0 +1,279 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2019 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#define __NEED_RMEM_CACHE
+
+#include <nanvix/runtime/rmem.h>
+#include <ulibc/stdio.h>
+#include <ulibc/string.h>
+#include "../../test.h"
+
+/*============================================================================*
+ * API Test: Alloc Free                                                       *
+ *============================================================================*/
+
+/**
+ * @brief API Test: Alloc Free
+ */
+static void test_rmem_rcache_alloc_free(void)
+{
+	rpage_t page_num;
+	rpage_t page_num1;
+
+	TEST_ASSERT((page_num = nanvix_rcache_alloc()) != RMEM_NULL);
+	TEST_ASSERT((page_num1 = nanvix_rcache_alloc()) != RMEM_NULL);
+	TEST_ASSERT(nanvix_rcache_free(page_num1) == 0);
+	TEST_ASSERT(nanvix_rcache_free(page_num) == 0);
+}
+
+/*============================================================================*
+ * API Test: Cache Put Write                                                  *
+ *============================================================================*/
+
+/**
+ * @brief API Test: Cache Put Write
+ */
+static void test_rmem_rcache_put_write(void)
+{
+	rpage_t page_num;
+	static char *cache_data;
+
+	TEST_ASSERT((page_num = nanvix_rcache_alloc()) != RMEM_NULL);
+	TEST_ASSERT((cache_data = nanvix_rcache_get(page_num)) != NULL);
+	nanvix_memset(cache_data, 1, RMEM_BLOCK_SIZE);
+
+	nanvix_rcache_select_write(RMEM_CACHE_WRITE_BACK);
+	TEST_ASSERT(nanvix_rcache_put(page_num) == 0);
+	TEST_ASSERT(nanvix_rcache_put(page_num) < 0);
+
+	TEST_ASSERT((cache_data = nanvix_rcache_get(page_num)) != NULL);
+
+	nanvix_rcache_select_write(RMEM_CACHE_WRITE_THROUGH);
+	TEST_ASSERT(nanvix_rcache_put(page_num) == 0);
+	TEST_ASSERT(nanvix_rcache_put(page_num) < 0);
+
+	TEST_ASSERT(nanvix_rcache_free(page_num) == 0);
+}
+
+/*============================================================================*
+ * API Test: Cache Get Flush                                                  *
+ *============================================================================*/
+
+/**
+ * @brief API Test: Cache Get Flush
+ */
+static void test_rmem_rcache_get_flush(void)
+{
+	rpage_t page_num[5];
+	static char *cache_data;
+
+	for (int i = 0; i < 5; i++)
+	{
+		TEST_ASSERT((page_num[i] = nanvix_rcache_alloc()) != RMEM_NULL);
+		TEST_ASSERT((cache_data = nanvix_rcache_get(page_num[i])) != NULL);
+		nanvix_memset(cache_data, i, RMEM_BLOCK_SIZE);
+	}
+
+	for (int i = 0; i < 5; i++)
+		TEST_ASSERT(nanvix_rcache_flush(page_num[i]) == 0);
+
+	TEST_ASSERT((cache_data = nanvix_rcache_get(page_num[3])) != NULL);
+
+	/* Checksum */
+	for (int i = 0; i < RMEM_BLOCK_SIZE; i++)
+		TEST_ASSERT(cache_data[i] == 3);
+
+	for (int i = 0; i < 5; i++)
+		TEST_ASSERT(nanvix_rcache_free(page_num[i]) == 0);
+}
+
+/*============================================================================*
+ * API Test: Cache FiFo                                                       *
+ *============================================================================*/
+
+/**
+ * @brief API Test: Cache FiFo
+ */
+static void test_rmem_rcache_fifo(void)
+{
+	rpage_t page_num[6];
+	static char *cache_data;
+
+	nanvix_rcache_select_replacement_policy(RMEM_CACHE_FIFO);
+
+	for (int i = 0; i < 5; i++)
+	{
+		TEST_ASSERT((page_num[i] = nanvix_rcache_alloc()) != RMEM_NULL);
+		TEST_ASSERT((cache_data = nanvix_rcache_get(page_num[i])) != NULL);
+		nanvix_memset(cache_data, i, RMEM_BLOCK_SIZE);
+	}
+
+	for (int i = 0; i < 5; i++)
+		TEST_ASSERT(nanvix_rcache_flush(page_num[i]) == 0);
+
+	/* Eviction will occur */
+	TEST_ASSERT((page_num[5] = nanvix_rcache_alloc()) != RMEM_NULL);
+	TEST_ASSERT((cache_data = nanvix_rcache_get(page_num[5])) != NULL);
+
+	/* Checksum */
+	for (int i = 0; i < RMEM_BLOCK_SIZE; i++)
+		TEST_ASSERT(cache_data[i] == 0);
+
+	/* Check if the page was evicted */
+	TEST_ASSERT(nanvix_rcache_flush(page_num[0]) < 0);
+
+	/* Another eviction will occur */
+	TEST_ASSERT((cache_data = nanvix_rcache_get(page_num[0])) != NULL);
+
+	/* Checksum */
+	for (int i = 0; i < RMEM_BLOCK_SIZE; i++)
+		TEST_ASSERT(cache_data[i] == 0);
+
+	/* Check if the page was evicted */
+	TEST_ASSERT(nanvix_rcache_flush(page_num[1]) < 0);
+
+	for (int i = 0; i < 5; i++)
+		TEST_ASSERT(nanvix_rcache_free(page_num[i]) == 0);
+	TEST_ASSERT(nanvix_rcache_free(page_num[5]) == 0);
+}
+
+/*============================================================================*
+ * API Test: Cache LiFo                                                       *
+ *============================================================================*/
+
+/**
+ * @brief API Test: Cache LiFo
+ */
+static void test_rmem_rcache_lifo(void)
+{
+	rpage_t page_num[6];
+	static char *cache_data;
+
+	nanvix_rcache_select_replacement_policy(RMEM_CACHE_LIFO);
+
+	for (int i = 0; i < 5; i++)
+	{
+		TEST_ASSERT((page_num[i] = nanvix_rcache_alloc()) != RMEM_NULL);
+		TEST_ASSERT((cache_data = nanvix_rcache_get(page_num[i])) != NULL);
+		nanvix_memset(cache_data, i, RMEM_BLOCK_SIZE);
+	}
+
+	for (int i = 0; i < 5; i++)
+		TEST_ASSERT(nanvix_rcache_flush(page_num[i]) == 0);
+
+	/* Eviction will occur */
+	TEST_ASSERT((page_num[6] = nanvix_rcache_alloc()) != RMEM_NULL);
+	TEST_ASSERT((cache_data = nanvix_rcache_get(page_num[6])) != NULL);
+
+	/* Checksum */
+	for (int i = 0; i < RMEM_BLOCK_SIZE; i++)
+		TEST_ASSERT(cache_data[i] == 0);
+
+	/* Check if the page was evicted */
+	TEST_ASSERT(nanvix_rcache_flush(page_num[4]) < 0);
+
+	/* Another eviction will occur */
+	TEST_ASSERT((cache_data = nanvix_rcache_get(page_num[4])) != NULL);
+
+	/* Checksum */
+	for (int i = 0; i < RMEM_BLOCK_SIZE; i++)
+		TEST_ASSERT(cache_data[i] == 4);
+
+	/* Check if the page was evicted */
+	TEST_ASSERT(nanvix_rcache_flush(page_num[5]) < 0);
+
+	for (int i = 0; i < 5; i++)
+		TEST_ASSERT(nanvix_rcache_free(page_num[i]) == 0);
+	TEST_ASSERT(nanvix_rcache_free(page_num[5]) == 0);
+}
+
+/*============================================================================*
+ * API Test: Cache lru                                                        *
+ *============================================================================*/
+
+/**
+ * @brief API Test: Cache lru
+ */
+static void test_rmem_rcache_lru(void)
+{
+	rpage_t page_num[6];
+	static char *cache_data;
+
+	nanvix_rcache_select_replacement_policy(RMEM_CACHE_LRU);
+
+	for (int i = 0; i < 5; i++)
+	{
+		TEST_ASSERT((page_num[i] = nanvix_rcache_alloc()) != RMEM_NULL);
+		TEST_ASSERT((cache_data = nanvix_rcache_get(page_num[i])) != NULL);
+		nanvix_memset(cache_data, i, RMEM_BLOCK_SIZE);
+	}
+
+	for (int i = 0; i < 5; i++)
+		TEST_ASSERT(nanvix_rcache_flush(page_num[i]) == 0);
+
+	/* Eviction will occur */
+	TEST_ASSERT((page_num[6] = nanvix_rcache_alloc()) != RMEM_NULL);
+	TEST_ASSERT((cache_data = nanvix_rcache_get(page_num[6])) != NULL);
+
+	/* Checksum */
+	for (int i = 0; i < RMEM_BLOCK_SIZE; i++)
+		TEST_ASSERT(cache_data[i] == 0);
+
+	/* Check if the page was evicted */
+	TEST_ASSERT(nanvix_rcache_flush(page_num[0]) < 0);
+
+	/* Another access on page 1 */
+	TEST_ASSERT((cache_data = nanvix_rcache_get(page_num[1])) != NULL);
+
+	/* Checksum */
+	for (int i = 0; i < RMEM_BLOCK_SIZE; i++)
+		TEST_ASSERT(cache_data[i] == 1);
+
+	/* Another eviction will occur */
+	TEST_ASSERT((cache_data = nanvix_rcache_get(page_num[0])) != NULL);
+
+	/* Check if the page was evicted */
+	TEST_ASSERT(nanvix_rcache_flush(page_num[2]) < 0);
+
+	for (int i = 0; i < 5; i++)
+		TEST_ASSERT(nanvix_rcache_free(page_num[i]) == 0);
+	TEST_ASSERT(nanvix_rcache_free(page_num[5]) == 0);
+}
+
+/*============================================================================*
+ * Test Driver Table                                                          *
+ *============================================================================*/
+
+/**
+ * @brief Unit tests.
+ */
+struct test tests_rmem_cache_api[] = {
+	{ test_rmem_rcache_alloc_free, "alloc free" },
+	{ test_rmem_rcache_put_write,  "put write"  },
+	{ test_rmem_rcache_get_flush,  "get flush"  },
+	{ test_rmem_rcache_fifo,       "fifo"       },
+	{ test_rmem_rcache_lifo,       "lifo"       },
+	{ test_rmem_rcache_lru,        "lru"        },
+	{ NULL,                         NULL        },
+};

--- a/src/test/rmem/cache/driver.c
+++ b/src/test/rmem/cache/driver.c
@@ -1,0 +1,40 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2011-2018 Pedro Henrique Penna <pedrohenriquepenna@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.  THE SOFTWARE IS PROVIDED
+ * "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+ * LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <ulibc/stdio.h>
+#include "../../test.h"
+
+/* Import definitions. */
+extern struct test tests_rmem_cache_api[];
+
+/**
+ * @todo TODO: provide a detailed description for this function.
+ */
+void test_rmem_cache(void)
+{
+	/* Run API tests. */
+	for (int i = 0; tests_rmem_cache_api[i].test_fn != NULL; i++)
+	{
+		nanvix_printf("[nanvix][test][rmem][cache][api] %s\n", tests_rmem_cache_api[i].name);
+		tests_rmem_cache_api[i].test_fn();
+	}
+}

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -52,6 +52,11 @@
 	extern void test_rmem(void);
 
 	/**
+	 * @brief Launches regression tests on RMem Cache.
+	 */
+	extern void test_rmem_cache(void);
+
+	/**
 	 * @brief Horizontal line for tests.
 	 */
 	extern const char *HLINE;


### PR DESCRIPTION
# Description
In this PR, I introduce functions for rmem cache. More precisely, these functions are for: allocation and deallocation of pages; get and put of pages and algorithms for page eviction. Moreover, tests were made to achieve correctness of each new function. It is possible to change the write policy and cache algorithm at runtime.

# Related Issues

- [[rmem] Remote Memory Cache](https://github.com/nanvix/multikernel/issues/152)
- [[rmem] Unit Tests for Remote Memory Cache](https://github.com/nanvix/multikernel/issues/164)