### PR TITLE
[bug] Cache return reference is incorrect.

### DIFF
--- a/src/libruntime/mm/cache.c
+++ b/src/libruntime/mm/cache.c
@@ -403,9 +403,11 @@ static int nanvix_rcache_fifo(void)
 		}
 	}
 
-	if (nanvix_rcache_flush(cache_lines[slot_idx].pgnum) < 0)
-		return (-EFAULT);
-	return (slot_idx);
+	for (int i = 0; i < RMEM_CACHE_BLOCK_SIZE; i++)
+		if (nanvix_rcache_flush(cache_lines[slot_idx+i].pgnum) < 0)
+			return (-EFAULT);
+
+	return slot_idx;
 }
 
 /*============================================================================*
@@ -458,8 +460,9 @@ static int nanvix_rcache_lifo(void)
 		}
 	}
 
-	if (nanvix_rcache_flush(cache_lines[slot_idx].pgnum) < 0)
-		return (-EFAULT);
+	for (int i = 0; i < RMEM_CACHE_BLOCK_SIZE; i++)
+		if (nanvix_rcache_flush(cache_lines[slot_idx+i].pgnum) < 0)
+			return (-EFAULT);
 
 	return slot_idx;
 }

--- a/src/ubin/test/rmem/cache/api.c
+++ b/src/ubin/test/rmem/cache/api.c
@@ -106,8 +106,11 @@ static void test_rmem_rcache_get_flush(void)
 	/* Get and flush to every page possible except the last one allocated. */
 	for (int i = 0; i < RMEM_CACHE_LENGTH; i++)
 	{
-		TEST_ASSERT((cache_data = nanvix_rcache_get(page_num[i*RMEM_CACHE_BLOCK_SIZE])) != NULL);
-		umemset(cache_data, i+1, RMEM_BLOCK_SIZE);
+		for (int j = 0; j < RMEM_CACHE_BLOCK_SIZE; j++)
+		{
+			TEST_ASSERT((cache_data = nanvix_rcache_get(page_num[i*RMEM_CACHE_BLOCK_SIZE+j])) != NULL);
+			umemset(cache_data, i*RMEM_CACHE_BLOCK_SIZE+j, RMEM_BLOCK_SIZE);
+		}
 	}
 
 	for (int i = 0; i < RMEM_CACHE_LENGTH; i++)
@@ -119,11 +122,14 @@ static void test_rmem_rcache_get_flush(void)
 	/* Check if every page has the correct value. */
 	for (int i = 0; i < RMEM_CACHE_LENGTH; i++)
 	{
-		TEST_ASSERT((cache_data = nanvix_rcache_get(page_num[i*RMEM_CACHE_BLOCK_SIZE])) != NULL);
+		for (int j = 0; j < RMEM_CACHE_BLOCK_SIZE; j++)
+		{
+			TEST_ASSERT((cache_data = nanvix_rcache_get(page_num[i*RMEM_CACHE_BLOCK_SIZE+j])) != NULL);
 
-		/* Checksum */
-		for (size_t w = 0; w < RMEM_BLOCK_SIZE; w++)
-			TEST_ASSERT(cache_data[w] == (char)(i+1));
+			/* Checksum */
+			for (size_t w = 0; w < RMEM_BLOCK_SIZE; w++)
+				TEST_ASSERT(cache_data[w] == (char)(i*RMEM_CACHE_BLOCK_SIZE+j));
+		}
 	}
 
 	/* Free all used pages. */

--- a/src/ubin/test/rmem/cache/api.c
+++ b/src/ubin/test/rmem/cache/api.c
@@ -300,6 +300,7 @@ static void test_rmem_rcache_aging(void)
 
 	/* Check if the correct page was evicted */
 	TEST_ASSERT(nanvix_rcache_flush(page_num[0*RMEM_CACHE_BLOCK_SIZE]) == 0);
+	TEST_ASSERT(nanvix_rcache_flush(page_num[1*RMEM_CACHE_BLOCK_SIZE]) < 0);
 
 	/* Free every used page. */
 	for (int i = 0; i < (RMEM_CACHE_LENGTH+1)*RMEM_CACHE_BLOCK_SIZE; i++)

--- a/src/ubin/test/rmem/cache/driver.c
+++ b/src/ubin/test/rmem/cache/driver.c
@@ -31,6 +31,7 @@ extern struct test tests_rmem_cache_api[];
  */
 void test_rmem_cache(void)
 {
+	usrand(9876);
 	/* Run API tests. */
 	for (int i = 0; tests_rmem_cache_api[i].test_fn != NULL; i++)
 	{


### PR DESCRIPTION
# Description

In the previous implementation, we had incorrect indexes being passed to the manager. Hence, in this PR it is introduced new ways to search for pages. This is necessary to pass indexes correctly to the cache manager. Moreover, tests for more blocks per slot were added.