### PR TITLE
[bugfix] Kportal Port Calc

### DIFF
--- a/src/libruntime/pm/portal.c
+++ b/src/libruntime/pm/portal.c
@@ -507,5 +507,5 @@ int nanvix_portal_get_port(int portalid)
 	if (!resource_is_wronly(&portals[portalid].resource))
 		return (-EINVAL);
 
-	return (portals[portalid].portalid % KPORTAL_PORT_NR);
+	return (kcomm_get_port(portals[portalid].portalid, COMM_TYPE_PORTAL));
 }

--- a/src/sys/mm/rmem/main.c
+++ b/src/sys/mm/rmem/main.c
@@ -424,7 +424,7 @@ static inline int do_rmem_read(int remote, rpage_t blknum, int outbox, int outpo
 			outport)
 		) >= 0
 	);
-	msg.header.portal_port = outportal % KPORTAL_PORT_NR;
+	msg.header.portal_port = kcomm_get_port(outportal, COMM_TYPE_PORTAL);
 	uassert(
 		kmailbox_write(outbox,
 			&msg,


### PR DESCRIPTION
# Description #
In this PR, a small correction to the kportal get_port calc was made. Now, the kernel exports a kernel call to extract the port from a communicator id, useful for the kportal interface.