### PR TITLE
[pm] Use Sync in Startup Barrier

### DIFF
--- a/src/sbin/spawn/main.c
+++ b/src/sbin/spawn/main.c
@@ -98,8 +98,8 @@ int __main2(int argc, const char *argv[])
 		uprintf("[nanvix][%s] listening to inbox %d", spawner_name, stdinbox_get());
 		uprintf("[nanvix][%s] syncing in sync %d", spawner_name, stdsync_get());
 
-		uassert(stdsync_fence() == 0);
 		spawn_barrier_setup();
+		uassert(stdsync_fence() == 0);
 
 		/* Spawn servers. */
 		for (int ring = SPAWN_RING_FIRST; ring <= SPAWN_RING_LAST; ring++)


### PR DESCRIPTION
# Description

In this PR I change the implementation of the startup barrier, so that it relies on the `sync` abstraction.