### PR TITLE
[vfs] Broken Header

### DIFF
--- a/include/nanvix/servers/vfs/fs.h
+++ b/include/nanvix/servers/vfs/fs.h
@@ -188,7 +188,7 @@
 	/**
 	 * @brief Root File System
 	 */
-	struct filesystem fs_root;
+	extern struct filesystem fs_root;
 
 /*============================================================================*
  * Interface for Refule Files                                                 *


### PR DESCRIPTION
### DESCRIPTION
Some systems fail to build while complaining about multiple definition of the globally declared fs_root struct.
Added extern keyword to fix it.