### PR TITLE
[ikc][name] Enhancement: Named IKC and Connections extensions 

### DIFF
--- a/include/nanvix/limits/pm.h
+++ b/include/nanvix/limits/pm.h
@@ -68,6 +68,15 @@
 	 */
 	#define NANVIX_CONNECTIONS_MAX NANVIX_PROC_MAX
 
+	/**
+	 * @brief Defines the base for the general purpose ports range for communicators.
+	 *
+	 * @note It's the first not reserved port for standard structures of the IKC module.
+	 *
+	 * @note Just a workaround. Redefine to at least 16 when possible.
+	 */
+	#define NANVIX_GENERAL_PORTS_BASE 13
+
 /*============================================================================*
  * System V Service                                                           *
  *============================================================================*/

--- a/include/nanvix/limits/pm.h
+++ b/include/nanvix/limits/pm.h
@@ -66,7 +66,7 @@
 	/**
 	 * @brief Maximum number of active connections in a server.
 	 */
-	#define NANVIX_CONNECTIONS_MAX NANVIX_PROC_MAX
+	#define NANVIX_CONNECTIONS_MAX (NANVIX_PROC_MAX * 4)
 
 	/**
 	 * @brief Defines the base for the general purpose ports range for communicators.

--- a/include/nanvix/runtime/pm/mailbox.h
+++ b/include/nanvix/runtime/pm/mailbox.h
@@ -63,6 +63,21 @@
 	extern int nanvix_mailbox_create(const char *name);
 
 	/**
+	 * @brief Creates a mailbox specifying the input port.
+	 *
+	 * @param name Mailbox name.
+	 * @param port Local port.
+	 *
+	 * @returns Upon successful completion, the ID of the new mailbox is
+	 * returned. Upon failure, a negative error code is returned instead.
+	 *
+	 * @note This function should be called only for creating mailboxes with
+	 * ports specified in the special range that is not related with the
+	 * standard ones.
+	 */
+	extern int nanvix_mailbox_create2(const char *name, int port);
+
+	/**
 	 * @brief Opens a mailbox.
 	 *
 	 * @param name Mailbox name.
@@ -84,6 +99,18 @@
 	 * a negative error code is returned instead.
 	 */
 	extern int nanvix_mailbox_read(int mbxid, void *buf, size_t n);
+
+	/**
+	 * @brief Specifies the mailbox remote for a single read.
+	 *
+	 * @param mbxid  ID of the target mailbox.
+	 * @param remote Remote nodenum.
+	 * @param port   Remote port number.
+	 *
+	 * @returns Upon successful completion zero is returned. Upon failure,
+	 * a negative error code is returned instead.
+	 */
+	extern int nanvix_mailbox_set_remote(int mbxid, int remote, int port);
 
 	/**
 	 * @brief Writes data to a mailbox.

--- a/include/nanvix/runtime/pm/portal.h
+++ b/include/nanvix/runtime/pm/portal.h
@@ -58,6 +58,21 @@
 	extern int nanvix_portal_create(const char *name);
 
 	/**
+	 * @brief Creates a portal specifying the input port.
+	 *
+	 * @param name Portal name.
+	 * @param port Local port.
+	 *
+	 * @returns Upon successful completion, the ID of the new portal is
+	 * returned. Upon failure, a negative error code is returned instead.
+	 *
+	 * @note This function should be called only for creating portals with
+	 * ports specified in the special range that is not related with the
+	 * standard ones.
+	 */
+	extern int nanvix_portal_create2(const char *name, int port);
+
+	/**
 	 * @brief Opens a portal.
 	 *
 	 * @param name Portal name.
@@ -79,6 +94,20 @@
 	 * @note This function is NOT thread-safe.
 	 */
 	extern int nanvix_portal_allow(int id, int nodenum);
+
+	/**
+	 * @brief Enables read operations on a portal specifying remote port.
+	 *
+	 * @param id	   ID of the target portal.
+	 * @param nodenum  Target node.
+	 * @param port     Remote port.
+	 *
+	 * @returns Upons successful completion zero is returned. Upon failure,
+	 * a negative error code is returned instead.
+	 *
+	 * @note This function is NOT thread-safe.
+	 */
+	extern int nanvix_portal_allow2(int id, int nodenum, int port);
 
 	/**
 	 * @brief Closes a portal.

--- a/src/ubin/test/name/api.c
+++ b/src/ubin/test/name/api.c
@@ -52,6 +52,28 @@ static void test_name_link_unlink(void)
 }
 
 /*============================================================================*
+ * API Test: Double Link                                                      *
+ *============================================================================*/
+
+/**
+ * @brief API Test: Double Link
+ */
+static void test_name_double_link(void)
+{
+	int nodenum;
+	char pathname[NANVIX_PROC_NAME_MAX];
+
+	nodenum = knode_get_num();
+
+	/* Link name. */
+	ustrcpy(pathname, "cool-name");
+	TEST_ASSERT(nanvix_name_link(nodenum, pathname) == 0);
+	TEST_ASSERT(nanvix_name_link(nodenum, pathname) == 0);
+	TEST_ASSERT(nanvix_name_unlink(pathname) == 0);
+	TEST_ASSERT(nanvix_name_unlink(pathname) == 0);
+}
+
+/*============================================================================*
  * API Test: Lookup                                                           *
  *============================================================================*/
 
@@ -100,6 +122,7 @@ static void test_name_heartbeat(void)
  */
 struct test tests_name_api[] = {
 	{ test_name_link_unlink, "link unlink"    },
+	{ test_name_double_link, "double link"    },
 	{ test_name_lookup,      "lookup"         },
 	{ test_name_heartbeat,   "heartbeat"      },
 	{ NULL,                   NULL            }

--- a/src/ubin/test/name/fault.c
+++ b/src/ubin/test/name/fault.c
@@ -69,27 +69,6 @@ static void test_name_bad_link(void)
 }
 
 /*============================================================================*
- * Fault Injection Test: Double Link                                          *
- *============================================================================*/
-
-/**
- * @brief Fault Injection Test: Double Link
- */
-static void test_name_double_link(void)
-{
-	int nodenum;
-	char pathname[NANVIX_PROC_NAME_MAX];
-
-	nodenum = knode_get_num();
-
-	/* Link name. */
-	ustrcpy(pathname, "cool-name");
-	TEST_ASSERT(nanvix_name_link(nodenum, pathname) == 0);
-	TEST_ASSERT(nanvix_name_link(nodenum, pathname) < 0);
-	TEST_ASSERT(nanvix_name_unlink(pathname) == 0);
-}
-
-/*============================================================================*
  * Fault Injection Test: Invalid Unlink                                       *
  *============================================================================*/
 
@@ -189,7 +168,6 @@ static void test_name_invalid_lookup(void)
 struct test tests_name_fault[] = {
 	{ test_name_invalid_link,   "invalid link"   },
 	{ test_name_bad_link,       "bad link"       },
-	{ test_name_double_link,    "double link"    },
 	{ test_name_invalid_unlink, "invalid unlink" },
 	{ test_name_bad_unlink,     "bad unlink"     },
 	{ test_name_double_unlink,  "double unlink"  },


### PR DESCRIPTION
In this PR, we introduce the following two enhancement.

## 1. [ikc] New Named Abstractions Functions

### 1.1 Description

In this PR, we provide a new function for Mailboxes and Portals that permits the user to define which port it wants to be allocated during the abstractions creation. It gives to the user a new range of general-purpose ports in which it can have finer control over it. It is important to be noted that these functions can only be called over this special range of ports which don't interfere over the kernel reserved ones. Ports that are specifically destined to address user threads cannot be allocated in this new way.

The new functions added are:
- `nanvix_mailbox_create2(name, port)`
- `mailbox_set_remote(remotenum)`
- `nanvix_portal_create2(name, port)`
- `nanvix_portal_allow2(name, port)`

### 1.2 Linked Issue

- Closes #222 - [[ikc] Specifying Port Number in Abstractions Create](https://github.com/nanvix/multikernel/issues/222)

## 2. [name] Allow multiple name links of the same name on Connections

### 2.1 Description

In this PR we updated the name server to use the new abstraction `Connection`, and work with multiple name links of the same name to the same node. Now, it is possible to link the same name multiple times without incurring in runtime errors or duplicate registers.

### 2.2 Linked Issues

- Closes #220 - [[name] Multiple Name Links](https://github.com/nanvix/multikernel/issues/220)

### 2.3 Dependencies (IMPORTANT)

This PR has unresolved dependencies related to the Nanvix kernel. The dependencies are described in [nanvix/microkernel#270](https://github.com/nanvix/microkernel/issues/270) and have implicancy in [nanvix/microkernel#271](https://github.com/nanvix/microkernel/issues/271).
To avoid these limitations, this PR has a workaround where it defines the special range to start in `NANVIX_GENERAL_PORTS_BASE = 13` at `nanvix/limits/pm.h`, specifying a small portion of the standard ports range. This should be corrected ASAP to avoid system conflicts and is implemented this way here ONLY to keep the development going on.