### PR TITLE
[sysv] Bad Declaration

### DIFF
--- a/src/ubin/test/sysv/fault.c
+++ b/src/ubin/test/sysv/fault.c
@@ -34,7 +34,7 @@
 /**
  * Used for tests.
  */
-char msgp[NANVIX_MSG_SIZE_MAX];
+static char msgp[NANVIX_MSG_SIZE_MAX];
 
 /**
  * @brief Fault Injection Test: Invalid Get

--- a/src/ubin/test/sysv/stress.c
+++ b/src/ubin/test/sysv/stress.c
@@ -34,7 +34,7 @@
 /**
  * Used for tests.
  */
-char msgp[NANVIX_MSG_SIZE_MAX];
+static char msgp[NANVIX_MSG_SIZE_MAX];
 
 /**
  * @brief Stress Test: Get / Close 1


### PR DESCRIPTION
### Description
Some systems fail to build and complain about multiple definition of a global char array that has the same name in two different .c files.

Added the static keyword so the arrays are only visible within their respective .c file and no multiple definition happens.
