### PR TITLE
[runtime] Barrier Header in runtime.h

### DIFF
--- a/include/nanvix/runtime/runtime.h
+++ b/include/nanvix/runtime/runtime.h
@@ -29,6 +29,7 @@
 	#include <nanvix/runtime/mm.h>
 	#include <nanvix/runtime/fs.h>
 	#include <nanvix/runtime/stdikc.h>
+	#include <nanvix/runtime/barrier.h>
 
 	/**
 	 * @brief Initializes the runtime.


### PR DESCRIPTION
# Description
In this PR nanvix/runtime/barrier.h is added to nanvix/runtime/runtime.h.

This closes #229 