### PR TITLE
[runtime] Preparing for Bigger LWMPI Environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ include/nanvix/kernel/
 # Nanvix Library
 include/nanvix/runtime/barrier.h
 include/nanvix/runtime/stdikc.h
+include/nanvix/runtime/fence.h
 include/nanvix/sys/
 
 # C Library

--- a/include/nanvix/runtime/pm/mailbox.h
+++ b/include/nanvix/runtime/pm/mailbox.h
@@ -148,4 +148,15 @@
 	 */
 	int nanvix_mailbox_unlink(int mbxid);
 
+	/**
+	 * @brief Returns the port number of a mailbox.
+	 *
+	 * @bpara mbxid ID of the target mailbox.
+	 *
+	 * @returns Upon successful completion the port number where the
+	 * target mailbox is hooked up is returned. Upon failure, a negative
+	 * error code is returned instead.
+	 */
+	extern int nanvix_mailbox_get_port(int mbxid);
+
 #endif /* NANVIX_RUNTIME_MAILBOX_H_ */

--- a/makefile
+++ b/makefile
@@ -49,6 +49,9 @@ export SUPPRESS_TESTS ?= no
 # Extras
 export ADDONS ?=
 
+# Uses LWMPI?
+export NANVIX_LWMPI ?= 0
+
 #===============================================================================
 # Directories
 #===============================================================================
@@ -102,6 +105,9 @@ export CFLAGS += $(ADDONS)
 
 # Enable sync and portal implementation that uses mailboxes
 export CFLAGS += -D__NANVIX_IKC_USES_ONLY_MAILBOX=0
+
+# Enable LWMPI environment setup
+export CFLAGS += -D__NANVIX_USES_LWMPI=$(NANVIX_LWMPI)
 
 # Additional C Flags
 include $(BUILDDIR)/makefile.cflags

--- a/src/libruntime/crt1.c
+++ b/src/libruntime/crt1.c
@@ -35,6 +35,8 @@ extern int __main3(int argc, const char *argv[]);
 
 #if __NANVIX_USES_LWMPI
 
+	extern int __main_wrapper(int argc, const char *argv[]);
+
 	/**
 	 * Routine that prepare the MPI Runtime environment.
 	 */
@@ -44,6 +46,12 @@ extern int __main3(int argc, const char *argv[]);
 	 * Routine that cleanup the MPI Runtime environment.
 	 */
 	extern int __mpi_processes_finalize(void);
+
+#else
+
+	static inline int __main_wrapper(int argc, const char *argv[]) {
+		return (__main3(argc, argv));
+	}
 
 #endif
 
@@ -80,7 +88,7 @@ int __main2(int argc, const char *argv[])
 
 		uassert(stdsync_fence() == 0);
 
-		__main3(argc, argv);
+		__main_wrapper(argc, argv);
 
 		/* Join the user processes. */
 #if __NANVIX_USES_LWMPI

--- a/src/libruntime/crt1.c
+++ b/src/libruntime/crt1.c
@@ -32,8 +32,24 @@
  */
 extern int __main3(int argc, const char *argv[]);
 
+
+#if __NANVIX_USES_LWMPI
+
+	/**
+	 * Routine that prepare the MPI Runtime environment.
+	 */
+	extern int __mpi_processes_init(int(*fn)(int, const char *[]), int argc, const char *argv[]);
+
+	/**
+	 * Routine that cleanup the MPI Runtime environment.
+	 */
+	extern int __mpi_processes_finalize(void);
+
+#endif
+
+
 /**
- * @brief Entry point for user-level prgraom.
+ * @brief Entry point for user-level program.
  */
 int __main2(int argc, const char *argv[])
 {
@@ -52,9 +68,28 @@ int __main2(int argc, const char *argv[])
 		__runtime_setup(SPAWN_RING_LAST);
 
 		uassert(nanvix_setpname(pname) == 0);
+
+		/* Spawn multiple threads simulating user processes. */
+#if __NANVIX_USES_LWMPI
+
+		uprintf("INITIALIZING MPI USER PROCESSES");
+
+		uassert(__mpi_processes_init(&__main3, argc, argv) == 0);
+
+#endif
+
 		uassert(stdsync_fence() == 0);
 
 		__main3(argc, argv);
+
+		/* Join the user processes. */
+#if __NANVIX_USES_LWMPI
+
+		uprintf("JOINING MPI USER PROCESSES");
+
+		uassert(__mpi_processes_finalize() == 0);
+
+#endif
 
 		uassert(nanvix_name_unlink(pname) == 0);
 		uassert(stdsync_fence() == 0);

--- a/src/libruntime/pm/mailbox.c
+++ b/src/libruntime/pm/mailbox.c
@@ -320,7 +320,7 @@ int nanvix_mailbox_set_remote(int mbxid, int remote, int port)
 	if (!WITHIN(port, 0, (MAILBOX_ANY_PORT + 1)))
 		return (-EINVAL);
 
-	ret = kmailbox_ioctl(mailboxes[mbxid].fd, KMAILBOX_IOCTL_SET_REMOTE, remote, port);
+	ret = kmailbox_set_remote(mailboxes[mbxid].fd, remote, port);
 
 	return (ret);
 }
@@ -451,6 +451,30 @@ int nanvix_mailbox_get_inbox(void)
 	local = knode_get_num();
 
 	return (inboxes[local]);
+}
+
+/*============================================================================*
+ * nanvix_mailbox_get_port()                                                  *
+ *============================================================================*/
+
+/**
+ * @todo TODO: Provide a detailed description for this function.
+ */
+int nanvix_mailbox_get_port(int mbxid)
+{
+	/* Invalid mailbox ID.*/
+	if (!nanvix_mailbox_is_valid(mbxid))
+		return (-EINVAL);
+
+	/*  Bad mailbox. */
+	if (!resource_is_used(&mailboxes[mbxid].resource))
+		return (-EINVAL);
+
+	/*  Bad mailbox. */
+	if (!resource_is_wronly(&mailboxes[mbxid].resource))
+		return (-EINVAL);
+
+	return (kcomm_get_port(mailboxes[mbxid].fd, COMM_TYPE_MAILBOX));
 }
 
 /*============================================================================*

--- a/src/libruntime/pm/mailbox.c
+++ b/src/libruntime/pm/mailbox.c
@@ -470,10 +470,6 @@ int nanvix_mailbox_get_port(int mbxid)
 	if (!resource_is_used(&mailboxes[mbxid].resource))
 		return (-EINVAL);
 
-	/*  Bad mailbox. */
-	if (!resource_is_wronly(&mailboxes[mbxid].resource))
-		return (-EINVAL);
-
 	return (kcomm_get_port(mailboxes[mbxid].fd, COMM_TYPE_MAILBOX));
 }
 

--- a/src/libruntime/pm/portal.c
+++ b/src/libruntime/pm/portal.c
@@ -608,9 +608,5 @@ int nanvix_portal_get_port(int portalid)
 	if (!resource_is_used(&portals[portalid].resource))
 		return (-EINVAL);
 
-	/*  Bad portal. */
-	if (!resource_is_wronly(&portals[portalid].resource))
-		return (-EINVAL);
-
 	return (kcomm_get_port(portals[portalid].portalid, COMM_TYPE_PORTAL));
 }

--- a/src/libruntime/pm/portal.c
+++ b/src/libruntime/pm/portal.c
@@ -196,7 +196,7 @@ int nanvix_portal_create(const char *name)
 		return (-EINVAL);
 
 	/* Runtime not initialized. */
-	if ((portalid = get_inportal()) < 0)
+	if ((portalid = stdinportal_get()) < 0)
 		return (-EAGAIN);
 
 	/* Allocate portal. */
@@ -214,6 +214,7 @@ int nanvix_portal_create(const char *name)
 	portals[id].owner = nodenum;
 	ustrcpy(portals[id].name, name);
 
+	inportals[core_get_id()] = id;
 	resource_set_rdonly(&portals[id].resource);
 
 	return (id);

--- a/src/sys/pm/name/main.c
+++ b/src/sys/pm/name/main.c
@@ -226,10 +226,10 @@ found:
 	procs[index].nodenum = nodenum;
 	procs[index].port_nr = remote_port;
 
+	nr_registration++;
+
 connect:
 	procs[index].refcount++;
-
-	nr_registration++;
 
 	return (0);
 }


### PR DESCRIPTION
# Description #
In this PR, we bring some important modifications to prepare the runtime to support a bigger LWMPI environment. It includes small bugfixes related to Portals initialization and the Name Service links counter, as so as modifications in the ```crt1``` file and in the build system to permit the overlying library to spawn threads as user processes.